### PR TITLE
Insert terms in the taxonomy dialog for an open term set

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
@@ -3,19 +3,13 @@
   "id": "68768334-bbaf-472e-a059-85436dbcc688",
   "alias": "TaxonomyPickerDemoWebPart",
   "componentType": "WebPart",
-
-  // The "*" signifies that the version should be taken from the package.json
   "version": "*",
   "manifestVersion": 2,
-
-  // If true, the component can only be installed on sites where Custom Script is allowed.
-  // Components that allow authors to embed arbitrary script code should set this to true.
-  // https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
   "requiresCustomScript": false,
 
   "preconfiguredEntries": [
     {
-      "groupId": "5c03119e-3074-46fd-976b-c60198311f70", // Other
+      "groupId": "5c03119e-3074-46fd-976b-c60198311f70",
       "group": { "default": "Other" },
       "title": { "default": "TaxonomyPickerDemo" },
       "description": { "default": " " },

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
@@ -24,7 +24,7 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
     const element: React.ReactElement<ITaxonomyPickerDemoProps> = React.createElement(
       TaxonomyPickerDemo,
       {
-        absoluteSiteUrl: this.context.pageContext.site.serverRelativeUrl,
+        absoluteSiteUrl: this.context.pageContext.site.absoluteUrl,
         termSetId: this.properties.termSetId,
         rootTermId: this.properties.rootTermId,
         itemLimit: this.properties.itemLimit

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -131,9 +131,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-karma/-/gulp-core-build-karma-4.3.6.tgz",
       "dependencies": {
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -309,9 +309,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-3.2.14.tgz",
       "dependencies": {
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -406,9 +406,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.77",
-      "from": "@microsoft/load-themed-styles@1.7.77",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.77.tgz"
+      "version": "1.8.29",
+      "from": "@microsoft/load-themed-styles@1.8.29",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.29.tgz"
     },
     "@microsoft/loader-cased-file": {
       "version": "1.4.1",
@@ -423,9 +423,9 @@
       }
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.60",
+      "version": "1.7.97",
       "from": "@microsoft/loader-load-themed-styles@>=1.7.29 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.60.tgz"
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.97.tgz"
     },
     "@microsoft/microsoft-graph-client": {
       "version": "1.0.0",
@@ -628,9 +628,9 @@
           "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.0.tgz"
         },
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -810,9 +810,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.4.1.tgz",
       "dependencies": {
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -1181,9 +1181,9 @@
       "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.6.tgz"
     },
     "@pnp/common": {
-      "version": "1.1.4",
+      "version": "1.2.3",
       "from": "@pnp/common@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.2.3.tgz",
       "dependencies": {
         "adal-angular": {
           "version": "1.0.17",
@@ -1193,19 +1193,19 @@
       }
     },
     "@pnp/logging": {
-      "version": "1.1.4",
+      "version": "1.2.3",
       "from": "@pnp/logging@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@pnp/logging/-/logging-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/@pnp/logging/-/logging-1.2.3.tgz"
     },
     "@pnp/odata": {
-      "version": "1.1.4",
+      "version": "1.2.3",
       "from": "@pnp/odata@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@pnp/odata/-/odata-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/@pnp/odata/-/odata-1.2.3.tgz"
     },
     "@pnp/sp": {
-      "version": "1.1.4",
+      "version": "1.2.3",
       "from": "@pnp/sp@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@pnp/sp/-/sp-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/@pnp/sp/-/sp-1.2.3.tgz"
     },
     "@rush-temp/build": {
       "version": "0.0.0",
@@ -1237,20 +1237,15 @@
       "from": "@types/adal@1.0.27",
       "resolved": "https://registry.npmjs.org/@types/adal/-/adal-1.0.27.tgz"
     },
-    "@types/adal-angular": {
-      "version": "1.0.1",
-      "from": "@types/adal-angular@1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/adal-angular/-/adal-angular-1.0.1.tgz"
-    },
     "@types/angular": {
-      "version": "1.6.50",
+      "version": "1.6.51",
       "from": "@types/angular@*",
-      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.50.tgz"
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.51.tgz"
     },
     "@types/argparse": {
-      "version": "1.0.34",
+      "version": "1.0.35",
       "from": "@types/argparse@>=1.0.33 <1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.34.tgz"
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.35.tgz"
     },
     "@types/assertion-error": {
       "version": "1.0.30",
@@ -1258,9 +1253,9 @@
       "resolved": "https://registry.npmjs.org/@types/assertion-error/-/assertion-error-1.0.30.tgz"
     },
     "@types/bluebird": {
-      "version": "3.5.23",
+      "version": "3.5.24",
       "from": "@types/bluebird@*",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.23.tgz"
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz"
     },
     "@types/chai": {
       "version": "3.5.2",
@@ -1428,9 +1423,9 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz"
     },
     "@types/sharepoint": {
-      "version": "2016.1.1",
+      "version": "2016.1.2",
       "from": "@types/sharepoint@>=2016.1.0 <2017.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sharepoint/-/sharepoint-2016.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/@types/sharepoint/-/sharepoint-2016.1.2.tgz"
     },
     "@types/sinon": {
       "version": "1.16.34",
@@ -1448,9 +1443,9 @@
       "resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.32.tgz"
     },
     "@types/uglify-js": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "from": "@types/uglify-js@*",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -1505,14 +1500,14 @@
       "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.17.1.tgz"
     },
     "@uifabric/styling": {
-      "version": "5.32.0",
+      "version": "5.36.0",
       "from": "@uifabric/styling@>=5.3.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.32.0.tgz"
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.36.0.tgz"
     },
     "@uifabric/utilities": {
-      "version": "5.34.1",
+      "version": "5.34.2",
       "from": "@uifabric/utilities@>=5.34.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.34.1.tgz"
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.34.2.tgz"
     },
     "abab": {
       "version": "1.0.4",
@@ -1674,9 +1669,9 @@
       }
     },
     "append-transform": {
-      "version": "1.0.0",
-      "from": "append-transform@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz"
+      "version": "0.4.0",
+      "from": "append-transform@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
     },
     "aproba": {
       "version": "1.2.0",
@@ -1856,9 +1851,9 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.10 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -1910,9 +1905,9 @@
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz"
         },
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -1920,9 +1915,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
         },
         "source-map-support": {
-          "version": "0.5.8",
+          "version": "0.5.9",
           "from": "source-map-support@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz"
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz"
         }
       }
     },
@@ -2063,9 +2058,9 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2075,9 +2070,9 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2127,9 +2122,9 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz"
         },
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2151,9 +2146,9 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2163,9 +2158,9 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2175,9 +2170,9 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         }
       }
     },
@@ -2258,6 +2253,11 @@
       "from": "batch@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+    },
     "beeper": {
       "version": "1.1.1",
       "from": "beeper@>=1.0.0 <2.0.0",
@@ -2274,9 +2274,9 @@
       "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.3.1.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
+          "version": "3.5.2",
           "from": "bluebird@>=3.5.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz"
         }
       }
     },
@@ -2286,9 +2286,9 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz"
     },
     "binary-extensions": {
-      "version": "1.11.0",
+      "version": "1.12.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz"
     },
     "binaryextensions": {
       "version": "1.0.1",
@@ -2345,7 +2345,14 @@
     "body-parser": {
       "version": "1.18.3",
       "from": "body-parser@>=1.12.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz"
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "from": "iconv-lite@0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz"
+        }
+      }
     },
     "bonjour": {
       "version": "3.5.0",
@@ -2509,9 +2516,9 @@
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
+          "version": "3.5.2",
           "from": "bluebird@>=3.5.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz"
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2578,14 +2585,14 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000877",
+      "version": "1.0.30000902",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000877.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000902.tgz"
     },
     "caniuse-lite": {
-      "version": "1.0.30000877",
+      "version": "1.0.30000902",
       "from": "caniuse-lite@>=1.0.30000864 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000902.tgz"
     },
     "caseless": {
       "version": "0.12.0",
@@ -2652,14 +2659,14 @@
       }
     },
     "chownr": {
-      "version": "1.0.1",
+      "version": "1.1.1",
       "from": "chownr@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz"
     },
     "ci-info": {
-      "version": "1.3.1",
-      "from": "ci-info@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.1.tgz"
+      "version": "1.6.0",
+      "from": "ci-info@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz"
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -2768,14 +2775,14 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz"
     },
     "color-convert": {
-      "version": "1.9.2",
+      "version": "1.9.3",
       "from": "color-convert@>=1.9.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
     },
     "color-name": {
-      "version": "1.1.1",
-      "from": "color-name@1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+      "version": "1.1.3",
+      "from": "color-name@1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
     },
     "color-string": {
       "version": "0.3.0",
@@ -2798,9 +2805,9 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
     },
     "combined-stream": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "from": "combined-stream@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz"
     },
     "command-line-args": {
       "version": "5.0.2",
@@ -2816,11 +2823,6 @@
       "version": "1.0.1",
       "from": "commondir@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
-    },
-    "compare-versions": {
-      "version": "3.3.1",
-      "from": "compare-versions@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
@@ -2838,9 +2840,9 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "compressible": {
-      "version": "2.0.14",
+      "version": "2.0.15",
       "from": "compressible@>=2.0.5 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz"
     },
     "compression": {
       "version": "1.5.2",
@@ -2957,9 +2959,9 @@
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz"
     },
     "convert-source-map": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "convert-source-map@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz"
     },
     "cookie": {
       "version": "0.3.1",
@@ -3115,9 +3117,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz"
         },
         "postcss-modules-extract-imports": {
-          "version": "1.2.0",
+          "version": "1.2.1",
           "from": "postcss-modules-extract-imports@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
@@ -3356,14 +3358,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "default-require-extensions": {
-      "version": "2.0.0",
-      "from": "default-require-extensions@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "version": "1.0.0",
+      "from": "default-require-extensions@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "dependencies": {
         "strip-bom": {
-          "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+          "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
         }
       }
     },
@@ -3457,9 +3459,9 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
     },
     "detect-node": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "from": "detect-node@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz"
     },
     "dezalgo": {
       "version": "1.0.3",
@@ -3534,9 +3536,14 @@
       }
     },
     "duplexify": {
-      "version": "3.6.0",
+      "version": "3.6.1",
       "from": "duplexify@>=3.5.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3549,9 +3556,9 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz"
     },
     "electron-to-chromium": {
-      "version": "1.3.58",
+      "version": "1.3.82",
       "from": "electron-to-chromium@>=1.2.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz"
     },
     "elliptic": {
       "version": "6.4.1",
@@ -3655,9 +3662,9 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz"
     },
     "es-to-primitive": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "from": "es-to-primitive@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.46",
@@ -3680,9 +3687,9 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz"
     },
     "es6-promise": {
-      "version": "4.2.4",
+      "version": "4.2.5",
       "from": "es6-promise@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz"
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz"
     },
     "es6-set": {
       "version": "0.1.5",
@@ -4081,9 +4088,9 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
+          "version": "6.5.4",
           "from": "ajv@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz"
         },
         "ajv-keywords": {
           "version": "3.2.0",
@@ -4186,6 +4193,11 @@
       "from": "flagged-respawn@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz"
     },
+    "flatmap-stream": {
+      "version": "0.1.1",
+      "from": "flatmap-stream@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz"
+    },
     "flatten": {
       "version": "1.0.2",
       "from": "flatten@>=1.0.2 <2.0.0",
@@ -4197,13 +4209,13 @@
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz"
     },
     "follow-redirects": {
-      "version": "1.5.5",
+      "version": "1.5.9",
       "from": "follow-redirects@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         }
       }
@@ -4229,9 +4241,9 @@
       "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz"
     },
     "form-data": {
-      "version": "2.3.2",
+      "version": "2.3.3",
       "from": "form-data@>=2.3.2 <2.4.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz"
     },
     "formatio": {
       "version": "1.1.1",
@@ -4304,9 +4316,9 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
-      "version": "2.0.0",
+      "version": "2.3.1",
       "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
@@ -4356,9 +4368,9 @@
       "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.4.tgz"
     },
     "glob": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "from": "glob@>=7.0.5 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
@@ -4551,9 +4563,9 @@
       "resolved": "https://registry.npmjs.org/gulp-cache/-/gulp-cache-0.4.6.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
+          "version": "3.5.2",
           "from": "bluebird@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz"
         },
         "vinyl": {
           "version": "1.2.0",
@@ -4739,9 +4751,9 @@
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
         },
         "event-stream": {
-          "version": "3.3.4",
+          "version": "3.3.6",
           "from": "event-stream@>=3.3.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz"
         },
         "finalhandler": {
           "version": "0.4.0",
@@ -4757,11 +4769,6 @@
           "version": "0.4.11",
           "from": "iconv-lite@0.4.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
-        },
-        "map-stream": {
-          "version": "0.1.0",
-          "from": "map-stream@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
         },
         "mime": {
           "version": "1.3.4",
@@ -4835,9 +4842,14 @@
           }
         },
         "split": {
-          "version": "0.3.3",
-          "from": "split@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+          "version": "1.0.1",
+          "from": "split@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
+        },
+        "stream-combiner": {
+          "version": "0.2.2",
+          "from": "stream-combiner@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
@@ -5244,19 +5256,14 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz"
     },
     "handlebars": {
-      "version": "4.0.11",
+      "version": "4.0.12",
       "from": "handlebars@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "version": "0.6.1",
+          "from": "source-map@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
         }
       }
     },
@@ -5314,6 +5321,11 @@
       "from": "has-gulplog@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "from": "has-symbols@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz"
+    },
     "has-unicode": {
       "version": "2.0.1",
       "from": "has-unicode@>=2.0.0 <3.0.0",
@@ -5357,9 +5369,9 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "he": {
-      "version": "1.1.1",
-      "from": "he@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
+      "version": "1.2.0",
+      "from": "he@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5392,9 +5404,9 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz"
     },
     "html-comment-regex": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "from": "html-comment-regex@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz"
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -5412,9 +5424,9 @@
       "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz"
     },
     "html-minifier": {
-      "version": "3.5.20",
+      "version": "3.5.21",
       "from": "html-minifier@>=3.5.8 <4.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
       "dependencies": {
         "commander": {
           "version": "2.17.1",
@@ -5427,16 +5439,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
         },
         "uglify-js": {
-          "version": "3.4.7",
+          "version": "3.4.9",
           "from": "uglify-js@>=3.4.0 <3.5.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
-          "dependencies": {
-            "commander": {
-              "version": "2.16.0",
-              "from": "commander@>=2.16.0 <2.17.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz"
         }
       }
     },
@@ -5451,9 +5456,9 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
     },
     "http-parser-js": {
-      "version": "0.4.13",
+      "version": "0.5.0",
       "from": "http-parser-js@>=0.4.0",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz"
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz"
     },
     "http-proxy": {
       "version": "1.17.0",
@@ -5501,9 +5506,9 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
         },
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         },
         "micromatch": {
           "version": "2.3.11",
@@ -5530,9 +5535,9 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.23",
+      "version": "0.4.24",
       "from": "iconv-lite@>=0.4.13 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -5709,9 +5714,9 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz"
     },
     "is-ci": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "from": "is-ci@>=1.0.10 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz"
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -5846,7 +5851,7 @@
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
+      "from": "is-property@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-regex": {
@@ -5870,9 +5875,9 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz"
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "from": "is-symbol@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "is-symbol@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5977,21 +5982,9 @@
       }
     },
     "istanbul-api": {
-      "version": "1.3.1",
+      "version": "1.3.7",
       "from": "istanbul-api@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.5",
-          "from": "istanbul-lib-source-maps@>=1.2.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz"
     },
     "istanbul-instrumenter-loader": {
       "version": "3.0.1",
@@ -5999,24 +5992,24 @@
       "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz"
     },
     "istanbul-lib-coverage": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "from": "istanbul-lib-coverage@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz"
     },
     "istanbul-lib-hook": {
-      "version": "1.2.1",
-      "from": "istanbul-lib-hook@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz"
+      "version": "1.2.2",
+      "from": "istanbul-lib-hook@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz"
     },
     "istanbul-lib-instrument": {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "from": "istanbul-lib-instrument@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz"
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz"
     },
     "istanbul-lib-report": {
-      "version": "1.1.4",
-      "from": "istanbul-lib-report@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+      "version": "1.1.5",
+      "from": "istanbul-lib-report@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
@@ -6026,21 +6019,26 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.3",
+      "version": "1.2.6",
       "from": "istanbul-lib-source-maps@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
+          "version": "3.2.6",
           "from": "debug@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
+        },
+        "ms": {
+          "version": "2.1.1",
+          "from": "ms@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         }
       }
     },
     "istanbul-reports": {
-      "version": "1.3.0",
-      "from": "istanbul-reports@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz"
+      "version": "1.5.1",
+      "from": "istanbul-reports@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz"
     },
     "istextorbinary": {
       "version": "1.0.2",
@@ -6425,9 +6423,9 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
     },
     "js-base64": {
-      "version": "2.4.8",
+      "version": "2.4.9",
       "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz"
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz"
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6438,6 +6436,11 @@
       "version": "3.9.1",
       "from": "js-yaml@>=3.9.1 <3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz"
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
     },
     "jsdom": {
       "version": "9.12.0",
@@ -6595,9 +6598,9 @@
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
     },
     "killable": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "killable@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz"
     },
     "kind-of": {
       "version": "6.0.2",
@@ -6657,9 +6660,9 @@
       }
     },
     "loader-runner": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "from": "loader-runner@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz"
     },
     "loader-utils": {
       "version": "1.1.0",
@@ -7064,9 +7067,9 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz"
     },
     "md5.js": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "from": "md5.js@>=1.3.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
@@ -7096,9 +7099,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "from": "merge@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz"
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -7141,14 +7144,14 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
     },
     "mime-db": {
-      "version": "1.35.0",
-      "from": "mime-db@>=1.35.0 <1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz"
+      "version": "1.37.0",
+      "from": "mime-db@>=1.37.0 <1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.19",
+      "version": "2.1.21",
       "from": "mime-types@>=2.1.19 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz"
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz"
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -7176,14 +7179,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "minipass": {
-      "version": "2.3.4",
+      "version": "2.3.5",
       "from": "minipass@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz"
     },
     "minizlib": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "minizlib@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz"
     },
     "mississippi": {
       "version": "2.0.0",
@@ -7331,9 +7334,9 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
     },
     "nan": {
-      "version": "2.10.0",
+      "version": "2.11.1",
       "from": "nan@>=2.10.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz"
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7341,9 +7344,9 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz"
     },
     "natives": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "natives@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz"
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7356,9 +7359,9 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
     "neo-async": {
-      "version": "2.5.2",
+      "version": "2.6.0",
       "from": "neo-async@>=2.5.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz"
     },
     "next-tick": {
       "version": "1.0.0",
@@ -7415,9 +7418,9 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.0.2.tgz"
     },
     "node-sass": {
-      "version": "4.9.3",
+      "version": "4.9.4",
       "from": "node-sass@>=4.8.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -7439,35 +7442,15 @@
           "from": "globule@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz"
         },
-        "har-validator": {
-          "version": "5.0.3",
-          "from": "har-validator@>=5.0.3 <5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
-        },
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.10 <4.18.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         },
         "lru-cache": {
           "version": "4.1.3",
           "from": "lru-cache@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-        },
-        "request": {
-          "version": "2.87.0",
-          "from": "request@2.87.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
         },
         "yallist": {
           "version": "2.1.2",
@@ -7656,14 +7639,14 @@
       "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
     },
     "opener": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "opener@>=1.4.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz"
     },
     "opn": {
-      "version": "5.3.0",
+      "version": "5.4.0",
       "from": "opn@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
@@ -7917,9 +7900,9 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pbkdf2": {
-      "version": "3.0.16",
+      "version": "3.0.17",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz"
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz"
     },
     "pend": {
       "version": "1.2.0",
@@ -7996,9 +7979,9 @@
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz"
     },
     "portfinder": {
-      "version": "1.0.17",
+      "version": "1.0.19",
       "from": "portfinder@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -8316,9 +8299,9 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
+          "version": "6.5.4",
           "from": "ajv@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz"
         },
         "ajv-keywords": {
           "version": "3.2.0",
@@ -8576,9 +8559,9 @@
       }
     },
     "postcss-modules": {
-      "version": "1.3.2",
+      "version": "1.4.1",
       "from": "postcss-modules@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.4.1.tgz",
       "dependencies": {
         "has-flag": {
           "version": "3.0.0",
@@ -8586,9 +8569,9 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
         },
         "postcss": {
-          "version": "7.0.2",
+          "version": "7.0.5",
           "from": "postcss@>=7.0.1 <8.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz"
         },
         "source-map": {
           "version": "0.6.1",
@@ -8597,7 +8580,7 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "from": "supports-color@>=5.4.0 <6.0.0",
+          "from": "supports-color@>=5.5.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
         }
       }
@@ -8860,9 +8843,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "3.3.0",
+      "version": "3.3.1",
       "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz"
     },
     "postcss-zindex": {
       "version": "2.2.0",
@@ -8981,9 +8964,9 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz"
     },
     "public-encrypt": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "from": "public-encrypt@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz"
     },
     "pump": {
       "version": "2.0.1",
@@ -9033,9 +9016,9 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "querystringify": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "querystringify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz"
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -9043,9 +9026,9 @@
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz"
     },
     "randomatic": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "from": "randomatic@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
@@ -9072,7 +9055,14 @@
     "raw-body": {
       "version": "2.3.3",
       "from": "raw-body@2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "from": "iconv-lite@0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz"
+        }
+      }
     },
     "react": {
       "version": "15.6.2",
@@ -9132,9 +9122,9 @@
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz"
     },
     "readdirp": {
-      "version": "2.1.0",
+      "version": "2.2.1",
       "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz"
     },
     "recast": {
       "version": "0.11.23",
@@ -9468,9 +9458,9 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
     },
     "selfsigned": {
-      "version": "1.10.3",
+      "version": "1.10.4",
       "from": "selfsigned@>=1.9.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
       "dependencies": {
         "node-forge": {
           "version": "0.7.5",
@@ -9591,11 +9581,6 @@
       "version": "2.0.0",
       "from": "set-blocking@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "set-value": {
       "version": "2.0.0",
@@ -9838,9 +9823,9 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz"
     },
     "sockjs-client": {
-      "version": "1.1.4",
-      "from": "sockjs-client@1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "version": "1.1.5",
+      "from": "sockjs-client@1.1.5",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
       "dependencies": {
         "faye-websocket": {
           "version": "0.11.1",
@@ -9855,9 +9840,9 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
     },
     "source-list-map": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "source-list-map@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -9895,14 +9880,14 @@
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz"
     },
     "spdx-correct": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "from": "spdx-correct@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz"
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "from": "spdx-exceptions@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz"
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
@@ -9910,9 +9895,9 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz"
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "from": "spdx-license-ids@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz"
     },
     "spdy": {
       "version": "3.4.7",
@@ -9940,9 +9925,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.14.2",
+      "version": "1.15.2",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz"
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz"
     },
     "ssri": {
       "version": "5.3.0",
@@ -9967,9 +9952,9 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
     },
     "stdout-stream": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "from": "stdout-stream@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz"
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -10091,9 +10076,9 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
+          "version": "6.5.4",
           "from": "ajv@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz"
         },
         "ajv-keywords": {
           "version": "3.2.0",
@@ -10140,9 +10125,14 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
+          "version": "3.2.6",
           "from": "debug@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
+        },
+        "ms": {
+          "version": "2.1.1",
+          "from": "ms@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
         }
       }
     },
@@ -10194,9 +10184,56 @@
       "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz"
     },
     "test-exclude": {
-      "version": "4.2.1",
+      "version": "4.2.3",
       "from": "test-exclude@>=4.2.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "from": "arr-diff@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "from": "array-unique@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+        },
+        "braces": {
+          "version": "1.8.5",
+          "from": "braces@>=1.8.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "from": "expand-brackets@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "from": "extglob@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "from": "is-extglob@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "from": "is-glob@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "from": "kind-of@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "from": "micromatch@>=2.3.11 <3.0.0",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+        }
+      }
     },
     "test-value": {
       "version": "3.0.0",
@@ -10234,9 +10271,9 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
     },
     "thunky": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "from": "thunky@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz"
     },
     "tildify": {
       "version": "1.2.0",
@@ -10394,16 +10431,9 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
     },
     "true-case-path": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "from": "true-case-path@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "from": "glob@>=6.0.4 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz"
     },
     "try-json-parse": {
       "version": "0.1.1",
@@ -10426,20 +10456,20 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
+          "version": "2.19.0",
           "from": "commander@>=2.12.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz"
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz"
         }
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "5.2.0",
+      "version": "5.2.1",
       "from": "tslint-microsoft-contrib@>=5.0.3 <6.0.0",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz",
       "dependencies": {
         "tsutils": {
           "version": "2.28.0",
-          "from": "tsutils@>=2.12.1 <3.0.0 <2.29.0",
+          "from": "tsutils@>=2.27.2 <3.0.0 <2.29.0",
           "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.28.0.tgz"
         }
       }
@@ -10468,6 +10498,11 @@
       "version": "0.6.0",
       "from": "tunnel-agent@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
     },
     "type-check": {
       "version": "0.3.2",
@@ -10500,9 +10535,9 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz"
     },
     "ua-parser-js": {
-      "version": "0.7.18",
+      "version": "0.7.19",
       "from": "ua-parser-js@>=0.7.18 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz"
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz"
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -10542,9 +10577,9 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
+          "version": "6.5.4",
           "from": "ajv@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz"
         },
         "ajv-keywords": {
           "version": "3.2.0",
@@ -10631,14 +10666,14 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
     },
     "unique-filename": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "unique-filename@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz"
     },
     "unique-slug": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "unique-slug@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz"
     },
     "unique-stream": {
       "version": "1.0.0",
@@ -10932,14 +10967,14 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
       "dependencies": {
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "ajv": {
-          "version": "6.5.3",
+          "version": "6.5.4",
           "from": "ajv@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz"
         },
         "ajv-keywords": {
           "version": "3.2.0",
@@ -11054,19 +11089,14 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz"
         },
         "acorn": {
-          "version": "5.7.1",
+          "version": "5.7.3",
           "from": "acorn@>=5.3.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
-        },
-        "body-parser": {
-          "version": "1.18.2",
-          "from": "body-parser@1.18.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
         },
         "commander": {
-          "version": "2.17.1",
+          "version": "2.19.0",
           "from": "commander@>=2.13.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz"
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz"
         },
         "etag": {
           "version": "1.8.1",
@@ -11074,9 +11104,9 @@
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
         },
         "express": {
-          "version": "4.16.3",
+          "version": "4.16.4",
           "from": "express@>=4.16.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz"
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz"
         },
         "finalhandler": {
           "version": "1.1.1",
@@ -11088,20 +11118,15 @@
           "from": "fresh@0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
         },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "from": "iconv-lite@0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
-        },
         "ipaddr.js": {
           "version": "1.8.0",
           "from": "ipaddr.js@1.8.0",
           "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz"
         },
         "lodash": {
-          "version": "4.17.10",
+          "version": "4.17.11",
           "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz"
         },
         "mime": {
           "version": "1.4.1",
@@ -11110,40 +11135,8 @@
         },
         "proxy-addr": {
           "version": "2.0.4",
-          "from": "proxy-addr@>=2.0.3 <2.1.0",
+          "from": "proxy-addr@>=2.0.4 <2.1.0",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz"
-        },
-        "qs": {
-          "version": "6.5.1",
-          "from": "qs@6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
-        },
-        "raw-body": {
-          "version": "2.3.2",
-          "from": "raw-body@2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "from": "depd@1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "from": "http-errors@1.6.2",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "from": "setprototypeof@1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "from": "safe-buffer@5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
         },
         "send": {
           "version": "0.16.2",
@@ -11173,16 +11166,16 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "dependencies": {
         "time-stamp": {
-          "version": "2.0.1",
+          "version": "2.2.0",
           "from": "time-stamp@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz"
         }
       }
     },
     "webpack-dev-server": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "from": "webpack-dev-server@>=2.11.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.5",
@@ -11194,27 +11187,15 @@
           "from": "anymatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz"
         },
-        "body-parser": {
-          "version": "1.18.2",
-          "from": "body-parser@1.18.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "from": "debug@2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-            }
-          }
-        },
         "chokidar": {
           "version": "2.0.4",
           "from": "chokidar@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz"
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "3.2.6",
           "from": "debug@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz"
         },
         "del": {
           "version": "3.0.0",
@@ -11227,14 +11208,19 @@
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
         },
         "express": {
-          "version": "4.16.3",
+          "version": "4.16.4",
           "from": "express@>=4.16.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "from": "debug@2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+            },
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
@@ -11247,6 +11233,11 @@
               "version": "2.6.9",
               "from": "debug@2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+            },
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
@@ -11275,7 +11266,7 @@
             "pify": {
               "version": "2.3.0",
               "from": "pify@^2.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
             }
           }
         },
@@ -11283,11 +11274,6 @@
           "version": "3.0.0",
           "from": "has-flag@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "from": "iconv-lite@0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
         },
         "ipaddr.js": {
           "version": "1.8.0",
@@ -11304,6 +11290,11 @@
           "from": "mime@1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
         },
+        "ms": {
+          "version": "2.1.1",
+          "from": "ms@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
+        },
         "pify": {
           "version": "3.0.0",
           "from": "pify@>=3.0.0 <4.0.0",
@@ -11311,40 +11302,8 @@
         },
         "proxy-addr": {
           "version": "2.0.4",
-          "from": "proxy-addr@>=2.0.3 <2.1.0",
+          "from": "proxy-addr@>=2.0.4 <2.1.0",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz"
-        },
-        "qs": {
-          "version": "6.5.1",
-          "from": "qs@6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
-        },
-        "raw-body": {
-          "version": "2.3.2",
-          "from": "raw-body@2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "from": "depd@1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "from": "http-errors@1.6.2",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "from": "setprototypeof@1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "from": "safe-buffer@5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
         },
         "send": {
           "version": "0.16.2",
@@ -11355,6 +11314,11 @@
               "version": "2.6.9",
               "from": "debug@2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+            },
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
@@ -11386,26 +11350,26 @@
       }
     },
     "webpack-notifier": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "from": "webpack-notifier@>=1.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-notifier/-/webpack-notifier-1.7.0.tgz",
       "dependencies": {
         "node-notifier": {
-          "version": "5.2.1",
+          "version": "5.3.0",
           "from": "node-notifier@>=5.1.2 <6.0.0",
-          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz"
         },
         "semver": {
-          "version": "5.5.1",
-          "from": "semver@>=5.4.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz"
+          "version": "5.6.0",
+          "from": "semver@>=5.5.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz"
         }
       }
     },
     "webpack-sources": {
-      "version": "1.1.0",
+      "version": "1.3.0",
       "from": "webpack-sources@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -11462,14 +11426,14 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz"
     },
     "whatwg-encoding": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "from": "whatwg-encoding@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz"
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
+      "version": "3.0.0",
       "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz"
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.module.scss
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.module.scss
@@ -1,50 +1,47 @@
 .dialog {
-  :global {
-    .ms-Dialog-main {
-      min-width: 40vw;
-
-      @media screen and (max-width: 1365px) {
-        min-width: 50vw;
-      }
-      @media screen and (max-width: 1023px) {
-        min-width: 70vw;
-      }
-      @media screen and (max-width: 639px) {
-        min-width: 80vw;
-      }
-      @media screen and (max-width: 479px) {
-        min-width: 90vw;
-      }
+    :global {
+        .ms-Dialog-main {
+            min-width: 40vw;
+            @media screen and (max-width: 1365px) {
+                min-width: 50vw;
+            }
+            @media screen and (max-width: 1023px) {
+                min-width: 70vw;
+            }
+            @media screen and (max-width: 639px) {
+                min-width: 80vw;
+            }
+            @media screen and (max-width: 479px) {
+                min-width: 90vw;
+            }
+        }
     }
-  }
 }
 
 .taxonomyTree {
-  border: 1px solid #a6a6a6;
-  box-sizing: border-box;
-  overflow-y: auto;
-  height: 325px;
-  padding: 2px 4px;
-  width: 100%;
+    border: 1px solid #a6a6a6;
+    box-sizing: border-box;
+    overflow-y: auto;
+    height: 325px;
+    padding: 2px 4px;
+    width: 100%;
 }
 
 .controls {
-  display: flex;
-  margin-top: 20px;
-
-  @media screen and (max-width: 479px) {
-    flex-direction: column;
-  }
+    display: flex;
+    margin-top: 20px;
+    @media screen and (max-width: 479px) {
+        flex-direction: column;
+    }
 }
 
 .addButton {
-  align-self: baseline;
-
-  @media screen and (max-width: 479px) {
-    width: 100%;
-  }
+    align-self: baseline;
+    @media screen and (max-width: 479px) {
+        width: 100%;
+    }
 }
 
 .termPicker {
-  flex-grow: 1;
+    flex-grow: 1;
 }

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -253,7 +253,11 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     this.state.selectedTreeItem ?
       await taxonomyApi.createTerm(this.state.newItemLabel!, Guid(), 1033, this.state.selectedTreeItem) :
       await taxonomyApi.createTerm(this.state.newItemLabel!, Guid());
-    this._loadTermSetData();
+    await this._loadTermSetData();
+
+    if (this.state.selectedTreeItem) {
+      this._onTreeSelectionChanged(this.state.selectedTreeItem);
+    }
   }
 
   @autobind

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -5,12 +5,14 @@ import { DefaultButton, PrimaryButton } from "office-ui-fabric-react/lib/Button"
 import { Dialog, DialogFooter, DialogType, IDialog } from "office-ui-fabric-react/lib/Dialog";
 import * as React from "react";
 
+import * as Guid from "uuid/v4";
 import { ITaxonomyApiContext, TaxonomyApi } from "../../api/TaxonomyApi";
 import { ITerm } from "../../model/ITerm";
 import { getClassName } from "../../utilities";
 import { TermPicker } from "../TermPicker";
 import { ITreeViewItem, TreeView } from "../TreeView";
 import { ITaxonomyDialogProps } from "./TaxonomyDialog.types";
+import { TermAdder } from "../TermAdder";
 
 const styles = require("./TaxonomyDialog.module.scss");
 
@@ -18,6 +20,9 @@ export interface ITaxonomyDialogState {
   selectedItems: ITerm[];
   selectedTreeItem: ITerm | null;
   treeViewData?: ITreeViewItem<ITerm>;
+  isOpenTermSet: boolean;
+  itemAdding: boolean;
+  newItemLabel?: string;
 }
 
 export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonomyDialogState>
@@ -35,7 +40,9 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
 
     this.state = {
       selectedItems: props.defaultSelectedItems || [],
-      selectedTreeItem: null
+      selectedTreeItem: null,
+      itemAdding: false,
+      isOpenTermSet: false
     };
   }
 
@@ -47,20 +54,26 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     return (
       <Dialog
         hidden={!this.props.isOpen}
-        onDismiss={this._onDismiss}
-        dialogContentProps={{
-          type: DialogType.close,
-          title: "Browse Term Set"
+        modalProps={{
+          isBlocking: true,
+          className: styles.dialog
         }}
-        className={styles.dialog}
-        isBlocking={true}
+        onDismiss={this._onDismiss}
+        dialogContentProps={{ type: DialogType.close, title: "Browse Term Set" }}
       >
+        {this.state.isOpenTermSet &&
+          <TermAdder addNewItemClick={this._onAddNewItemClick} />
+        }
         <div className={css(getClassName("TaxonomyDialog-Tree"), styles.taxonomyTree)}>
           <TreeView
             termSetId={this.props.termSetId}
+            isOpenTermSet={this.state.isOpenTermSet}
             data={this.state.treeViewData}
             onItemInvoked={this._onTreeItemInvoked}
             onSelectionChanged={this._onTreeSelectionChanged}
+            itemAdding={this.state.itemAdding}
+            onNewItemFocusOut={this._onNewItemFocusOut}
+            onNewItemValueChanged={this._onNewItemValueChanged}
           />
         </div>
 
@@ -86,7 +99,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
   }
 
   @autobind
-  private async _loadTermSetData(): Promise<void> {
+  private async _loadTermSetData(itemAdding: boolean = false): Promise<void> {
     const apiContext: ITaxonomyApiContext = {
       absoluteSiteUrl: this.props.absoluteSiteUrl,
       termSetId: this.props.termSetId,
@@ -98,9 +111,10 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     const rootTreeTerms = termTree.terms.filter(t => !!t.id && t.id === this.props.rootTermId);
     const rootTreeTerm = rootTreeTerms.length > 0 ? rootTreeTerms[0] : null;
 
-    const children = rootTreeTerm && rootTreeTerm.properties && rootTreeTerm.properties.children
-      ? rootTreeTerm.properties.children.map(this._termToTreeViewItem)
-      : termTree.terms.map(this._termToTreeViewItem);
+    const children =
+      rootTreeTerm && rootTreeTerm.properties && rootTreeTerm.properties.children
+        ? rootTreeTerm.properties.children.map(this._termToTreeViewItem)
+        : termTree.terms.map(this._termToTreeViewItem);
 
     this.setState({
       treeViewData: {
@@ -108,8 +122,10 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
         label: termTree.termSetName,
         children,
         value: null,
-        isSelectable: false
-      }
+        isSelectable: termTree.isOpenTermSet
+      },
+      itemAdding,
+      isOpenTermSet: termTree.isOpenTermSet
     });
   }
 
@@ -208,5 +224,42 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
       const newItems = [...currentItems, itemToAdd];
       this._onSelectedItemsChanged(newItems);
     }
+  }
+
+  @autobind
+  private _onAddNewItemClick(): void {
+    if (!this.state.itemAdding) {
+      this.setState({ itemAdding: true });
+    }
+  }
+
+  @autobind
+  private async _onNewItemFocusOut(): Promise<void> {
+    // Check if not empty, otherwise cancel
+    if (!this.state.newItemLabel) {
+      this.setState({
+        itemAdding: false
+      });
+      return Promise.resolve();
+    }
+
+    // Add the new term to the taxonomy
+    const apiContext: ITaxonomyApiContext = {
+      absoluteSiteUrl: this.props.absoluteSiteUrl,
+      termSetId: this.props.termSetId,
+      rootTermId: this.props.rootTermId
+    };
+    const taxonomyApi = new TaxonomyApi(apiContext);
+    this.state.selectedTreeItem ?
+      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid(), 1033, this.state.selectedTreeItem) :
+      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid());
+    this._loadTermSetData();
+  }
+
+  @autobind
+  private _onNewItemValueChanged(termLabel: string): void {
+    this.setState({
+      newItemLabel: termLabel
+    });
   }
 }

--- a/packages/react-fabric-taxonomypicker/src/components/TermAdder/TermAdder.module.scss
+++ b/packages/react-fabric-taxonomypicker/src/components/TermAdder/TermAdder.module.scss
@@ -1,0 +1,25 @@
+.termAdder {
+    word-break: normal;
+    padding-bottom: 10px;
+    .termAdderIcon {
+        padding-right: 15px;
+    }
+    .termAdderDescription {
+        vertical-align: top;
+        font-size: 16px;
+        font-weight: 400;
+        padding: 1px;
+    }
+    .termAdderLabel {
+        padding: 1px;
+        cursor: pointer;
+        vertical-align: top;
+        color: #0072c6;
+        text-decoration: none;
+        margin-left: 2px;
+        &:visited {
+            color: #663399;
+            text-decoration: none;
+        }
+    }
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TermAdder/TermAdder.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TermAdder/TermAdder.tsx
@@ -1,0 +1,28 @@
+import { css } from "@uifabric/utilities/lib";
+import * as React from "react";
+import { getClassName } from "../../utilities";
+const styles = require("./TermAdder.module.scss");
+
+export interface ITermAdderProps {
+  addNewItemClick: () => void;
+}
+
+export const TermAdder: React.StatelessComponent<ITermAdderProps> = ({
+  addNewItemClick
+}: ITermAdderProps) => (
+    <div className={css(getClassName("TaxonomyDialog-TermAdder"), styles.termAdder)}>
+      <img src="/_layouts/images/EMMDoubleTag.png" alt="" data-themekey="#" className={css(getClassName("TreeView-TermAdder-Icon"), styles.termAdderIcon)} />
+      <span
+        className={css(getClassName("TreeView-TermAdder-Description"), styles.termAdderDescription)}
+        id="addNewTermDescription"
+      >
+        New items are added under the currently selected item.
+      <span
+          className={css(getClassName("TreeView-TermAdder-Label"), styles.termAdderLabel)}
+          onClick={addNewItemClick}
+      >
+          Add New Item
+      </span>
+      </span>
+    </div>
+  );

--- a/packages/react-fabric-taxonomypicker/src/components/TermAdder/index.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TermAdder/index.ts
@@ -1,0 +1,1 @@
+export * from "./TermAdder";

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeLabelNew.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeLabelNew.tsx
@@ -1,0 +1,54 @@
+import { css } from "@uifabric/utilities/lib/css";
+import { Icon } from "office-ui-fabric-react/lib/Icon";
+import { TextField } from "office-ui-fabric-react/lib/TextField";
+import * as React from "react";
+import { autobind } from "@uifabric/utilities";
+
+import { getClassName } from "../../utilities";
+
+const styles = require("./TreeView.module.scss");
+
+export interface ITreeLabelNewProps {
+  label?: string;
+  onNewItemValueChanged?: (value: string) => void;
+  onNewItemFocusOut?: () => void;
+}
+
+export class TreeLabelNew extends React.Component<ITreeLabelNewProps, any> {
+  constructor(props: ITreeLabelNewProps) {
+    super(props);
+  }
+  public render(): JSX.Element {
+    return (
+      <div
+        className={css(getClassName("TreeView-NodeLabel"), styles.nodeLabel, styles.nodeLabelNew)}
+      >
+        <Icon
+          className={css(getClassName("TreeView-NodeLabel-TagIcon"), styles.tagIcon)}
+          iconName={"Tag"}
+        />
+        <TextField
+          autoFocus={true}
+          value={this.props.label}
+          onChanged={this._onNewItemValueChanged}
+          onBlur={this._onNewItemFocusOut}
+          className={css(getClassName("TreeView-NodeLabel-Text"), styles.labelText)}
+        />
+      </div>
+    );
+  }
+
+  @autobind
+  private _onNewItemValueChanged(newValue?: string): void {
+    if (newValue && this.props.onNewItemValueChanged) {
+      this.props.onNewItemValueChanged(newValue);
+    }
+  }
+
+  @autobind
+  private _onNewItemFocusOut(): void {
+    if (this.props.onNewItemFocusOut) {
+      this.props.onNewItemFocusOut();
+    }
+  }
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
@@ -38,7 +38,7 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
   public render(): JSX.Element {
     const { item, selection, isRootNode, isOpenTermSet, invokeItem, itemAdding, onNewItemValueChanged, onNewItemFocusOut, newItemValue } = this.props;
     const { isCollapsed } = this.state;
-
+    const isItemAddingBelowSelectedNode: boolean | undefined = itemAdding && selection.isKeySelected(item.id);
     return (
       <div
         className={css(getClassName("TreeView-Node"), styles.node, {
@@ -58,7 +58,7 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
           onToggleCollapse={this._toggleCollapse}
         />
 
-        {itemAdding && selection.isKeySelected(item.id) && (
+        {isItemAddingBelowSelectedNode && (
           <TreeLabelNew
             label={newItemValue}
             onNewItemValueChanged={onNewItemValueChanged}

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
@@ -6,14 +6,20 @@ import * as React from "react";
 import { getClassName } from "../../utilities";
 import { TreeLabel } from "./TreeLabel";
 import { ITreeViewItem } from "./TreeView.types";
+import { TreeLabelNew } from "./TreeLabelNew";
 
 const styles = require("./TreeView.module.scss");
 
 export interface ITreeNodeProps<T> {
   item: ITreeViewItem<T>;
   selection: ISelection;
+  isOpenTermSet: boolean;
+  isRootNode: boolean;
   defaultExpanded?: boolean;
-  isRootNode?: boolean;
+  itemAdding?: boolean;
+  newItemValue?: string;
+  onNewItemValueChanged?: (value: string) => void;
+  onNewItemFocusOut?: () => void;
   invokeItem?: (item: ITreeViewItem<T>) => void;
 }
 
@@ -30,7 +36,7 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
     };
   }
   public render(): JSX.Element {
-    const { item, selection, isRootNode, invokeItem } = this.props;
+    const { item, selection, isRootNode, isOpenTermSet, invokeItem, itemAdding, onNewItemValueChanged, onNewItemFocusOut, newItemValue } = this.props;
     const { isCollapsed } = this.state;
 
     return (
@@ -45,12 +51,20 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
           hasChildren={item.children && item.children.length > 0}
           isRootNode={isRootNode}
           isSelected={selection.isKeySelected(item.id)}
-          isSelectable={selection.canSelectItem({ ...item, key: item.id } as IObjectWithKey)}
+          isSelectable={(isRootNode && isOpenTermSet) || selection.canSelectItem({ ...item, key: item.id } as IObjectWithKey)}
           isExpanded={!isCollapsed}
           onClick={this._selectItem}
           onDoubleClick={this._invokeItem}
           onToggleCollapse={this._toggleCollapse}
         />
+
+        {itemAdding && selection.isKeySelected(item.id) && (
+          <TreeLabelNew
+            label={newItemValue}
+            onNewItemValueChanged={onNewItemValueChanged}
+            onNewItemFocusOut={onNewItemFocusOut}
+          />
+        )}
 
         {!isCollapsed &&
           item.children &&
@@ -58,9 +72,15 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
             <TreeNode
               key={child.id}
               item={child}
+              isRootNode={false}
               selection={selection}
+              isOpenTermSet={isOpenTermSet}
               defaultExpanded={isRootNode && index === 0}
               invokeItem={invokeItem}
+              onNewItemValueChanged={onNewItemValueChanged}
+              onNewItemFocusOut={onNewItemFocusOut}
+              itemAdding={itemAdding}
+              newItemValue={newItemValue}
             />
           ))}
       </div>

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.module.scss
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.module.scss
@@ -1,54 +1,65 @@
 .node:not(.isRootNode) {
-  margin-left: 16px;
+    margin-left: 16px;
 }
 
 .nodeLabel {
-  align-items: center;
-  box-sizing: border-box;
-  display: flex;
-  height: 24px;
-  padding-left: 14px;
-  position: relative;
-
-  &.isSelected {
-    .labelText {
-      background: linear-gradient(to bottom, #ffe47f 0%, #ffe6a0 50%, #ffbb47 51%, #ffe37d 100%);
-      border: 1px solid #ff9933;
-      padding: 0 11px 0 1px;
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    height: 24px;
+    padding-left: 14px;
+    position: relative;
+    &.isSelected {
+        .labelText {
+            background: linear-gradient(to bottom, #ffe47f 0%, #ffe6a0 50%, #ffbb47 51%, #ffe37d 100%);
+            border: 1px solid #ff9933;
+            padding: 0 11px 0 1px;
+        }
     }
-  }
-  &.isSelectable {
-    .labelText:hover {
-      border: 1px solid #ff9933;
-      cursor: pointer;
-      padding: 0 11px 0 1px;
+    &.isSelectable {
+        .labelText:hover {
+            border: 1px solid #ff9933;
+            cursor: pointer;
+            padding: 0 11px 0 1px;
+        }
     }
-  }
-  &:not(.isSelectable) {
-    .labelText:hover {
-      cursor: not-allowed;
+    &:not(.isSelectable) {
+        .labelText:hover {
+            cursor: not-allowed;
+        }
     }
-  }
 }
+
+.nodeLabelNew {
+    padding-left: 30px;
+    :global {
+        .ms-TextField-fieldGroup {
+            height: 22px;
+            line-height: 20px;
+        }
+    }
+}
+
 .expandIcon {
-  left: 0;
-  line-height: 24px;
-  position: absolute;
-  top: 0;
+    left: 0;
+    line-height: 24px;
+    position: absolute;
+    top: 0;
+    &:hover {
+        cursor: pointer;
+    }
+}
 
-  &:hover {
-    cursor: pointer;
-  }
-}
 .tagIcon {
-  line-height: 24px;
-  margin: 0 3px;
+    line-height: 24px;
+    margin: 0 3px;
 }
+
 .labelText {
-  box-sizing: border-box;
-  display: inline-block;
-  font-size: 0.75em;
-  height: 22px;
-  line-height: 20px;
-  padding: 1px 12px 1px 2px;
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: 0.75em;
+    height: 22px;
+    line-height: 20px;
+    padding: 1px 12px 1px 2px;
 }

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.tsx
@@ -43,7 +43,7 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
   }
 
   public render(): JSX.Element {
-    const { data } = this.props;
+    const { data, isOpenTermSet, onItemInvoked, onNewItemValueChanged, onNewItemFocusOut, itemAdding } = this.props;
     const { selection } = this.state;
 
     return (
@@ -54,11 +54,14 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
             selection={selection}
             defaultExpanded={true}
             isRootNode={true}
-            invokeItem={this.props.onItemInvoked}
+            isOpenTermSet={isOpenTermSet}
+            invokeItem={onItemInvoked}
+            onNewItemValueChanged={onNewItemValueChanged}
+            onNewItemFocusOut={onNewItemFocusOut}
+            itemAdding={itemAdding}
           />
         )}
-      </div>
-    );
+    </div>);
   }
 
   @autobind

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
@@ -1,8 +1,12 @@
 export interface ITreeViewProps<T> {
   data?: ITreeViewItem<T>;
   termSetId: string;
+  itemAdding: boolean;
+  isOpenTermSet: boolean;
   onSelectionChanged?: (value: T | null) => void;
   onItemInvoked?: (item: ITreeViewItem<T>) => void;
+  onNewItemFocusOut?: () => void;
+  onNewItemValueChanged?: (value: string) => void;
 }
 
 export interface ITreeViewItem<T> {


### PR DESCRIPTION
Supports injection of new terms below the root node (added an "is open termset" boolean for this) and supports hierarchical insertion. Behavior is the same as the regular taxonomy picker. On focus out, the item will be inserted on the fly in the term set. Equal to the OOTB tax picker, this does not support multilingualism nor term deletion.

![addnewitem_1](https://user-images.githubusercontent.com/23431246/47796173-196dfd80-dd24-11e8-84fb-3134c17c974e.PNG)
![addnewitem_2](https://user-images.githubusercontent.com/23431246/47796175-196dfd80-dd24-11e8-9cd1-30ad015c8606.PNG)
![addnewitem_3](https://user-images.githubusercontent.com/23431246/47796178-1a069400-dd24-11e8-9b20-8a1ad630af39.PNG)
![addnewitem_4](https://user-images.githubusercontent.com/23431246/47796179-1a069400-dd24-11e8-964b-18060af71533.PNG)
![addnewitem_5](https://user-images.githubusercontent.com/23431246/47796180-1a069400-dd24-11e8-8ae2-70796b0ebea1.PNG)




