### PR TITLE
Show translated TreeNode labels based on LCID property

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
@@ -15,7 +15,8 @@
       "description": { "default": " " },
       "officeFabricIconFontName": "Page",
       "properties": {
-        "itemLimit": 5
+        "itemLimit": 5,
+        "lcid": 1033
       }
     }
   ]

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
@@ -15,6 +15,7 @@ export interface ITaxonomyPickerDemoWebPartProps {
   termSetId: string;
   rootTermId: string;
   itemLimit: number;
+  lcid: number;
 }
 
 export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
@@ -27,7 +28,8 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
         absoluteSiteUrl: this.context.pageContext.site.absoluteUrl,
         termSetId: this.properties.termSetId,
         rootTermId: this.properties.rootTermId,
-        itemLimit: this.properties.itemLimit
+        itemLimit: this.properties.itemLimit,
+        lcid: this.properties.lcid
       }
     );
 
@@ -57,6 +59,9 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
                 }),
                 PropertyPaneTextField("itemLimit", {
                   label: strings.ItemLimitFieldLabel
+                }),
+                PropertyPaneTextField("lcid", {
+                  label: strings.LcidFieldLabel
                 })
               ]
             }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
@@ -3,4 +3,5 @@ export interface ITaxonomyPickerDemoProps {
   termSetId: string;
   rootTermId: string;
   itemLimit: number;
+  lcid: number;
 }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -15,6 +15,7 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
           rootTermId={this.props.rootTermId}
           itemLimit={this.props.itemLimit}
           allowAddTerms={true}
+          lcid={this.props.lcid}
         />
       </div>
     );

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerLoader.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerLoader.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 
 export interface ITaxonomyPickerLoaderProps extends ITaxonomyPickerProps {
   absoluteSiteUrl: string;
+  lcid: number;
 }
 
 export interface ITaxonomyPickerLoaderState {

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
@@ -4,6 +4,7 @@ define([], function () {
     BasicGroupName: "Basic configuration",
     TermSetIdFieldLabel: "Term Set ID",
     RootTermIdFieldLabel: "Root Term ID",
-    ItemLimitFieldLabel: "Item Limit"
+    ItemLimitFieldLabel: "Item Limit",
+    LcidFieldLabel: "Locale ID"
   };
 });

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
@@ -4,6 +4,7 @@ declare interface ITaxonomyPickerDemoWebPartStrings {
   TermSetIdFieldLabel: string;
   RootTermIdFieldLabel: string;
   ItemLimitFieldLabel: string;
+  LcidFieldLabel: string;
 }
 
 declare module "TaxonomyPickerDemoWebPartStrings" {

--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-11-08-26.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-11-08-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "Fetch translated label by locale based on lcid property",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "klaas.lauwers@delaware.pro"
+}

--- a/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.types.ts
@@ -1,6 +1,7 @@
 export interface ITermData {
   id?: string;
   name: string;
+  defaultLabel: string;
   path: string;
   isSelectable: boolean;
   parentId: string | null;

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -108,7 +108,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     };
 
     const taxonomyApi = new TaxonomyApi(apiContext);
-    const termTree = await taxonomyApi.getTermTree();
+    const termTree = await taxonomyApi.getTermTree(this.props.lcid);
     const rootTreeTerms = termTree.terms.filter(t => !!t.id && t.id === this.props.rootTermId);
     const rootTreeTerm = rootTreeTerms.length > 0 ? rootTreeTerms[0] : null;
 
@@ -121,6 +121,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
       treeViewData: {
         id: this.props.termSetId,
         label: termTree.termSetName,
+        defaultLabel: termTree.termSetName,
         children,
         value: null,
         isSelectable: termTree.isOpenTermSet
@@ -135,10 +136,12 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     return {
       id: item.id!,
       label: item.name,
+      defaultLabel: item.defaultLabel,
       value: {
         id: item.id,
         name: item.name,
-        path: item.path
+        path: item.path,
+        defaultLabel: item.defaultLabel
       },
       children:
         item.properties && item.properties.children
@@ -267,8 +270,8 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
     };
     const taxonomyApi = new TaxonomyApi(apiContext);
     this.state.selectedTreeItem ?
-      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid(), 1033, this.state.selectedTreeItem) :
-      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid());
+      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid(), this.props.lcid, this.state.selectedTreeItem) :
+      await taxonomyApi.createTerm(this.state.newItemLabel!, Guid(), this.props.lcid);
     await this._loadTermSetData();
 
     if (this.state.selectedTreeItem) {

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
@@ -16,6 +16,8 @@ export interface ITaxonomyDialogProps extends IBaseProps {
 
   isOpen?: boolean;
 
+  lcid?: number;
+
   onSave?: (items: ITerm[]) => void;
   onDismiss?: () => void;
 }
@@ -23,19 +25,23 @@ export interface ITaxonomyDialogProps extends IBaseProps {
 export const testData: ITreeViewItem<ITerm | null> = {
   id: "7258f249-b4fd-4d53-949f-9b2628b51b08",
   label: "Root",
+  defaultLabel: "Root",
   children: [
     {
       id: "ab763b5c-9d6f-4478-a798-072f5f7a6c8c",
       label: "Term A",
+      defaultLabel: "Term A",
       children: [
         {
           id: "089328a1-dc3a-480b-a0bb-a800c6afa7e9",
           label: "Term A 1",
           children: [],
+          defaultLabel: "Term A 1",
           value: {
             id: "089328a1-dc3a-480b-a0bb-a800c6afa7e9",
             name: "Term A 1",
-            path: "Term A;Term A 1"
+            path: "Term A;Term A 1",
+            defaultLabel: "Term A 1"
           },
           isSelectable: true
         },
@@ -43,10 +49,12 @@ export const testData: ITreeViewItem<ITerm | null> = {
           id: "f29dffba-a335-4d68-8642-e4da4bc23ce9",
           label: "Term A 2",
           children: [],
+          defaultLabel: "Term A 2",
           value: {
             id: "f29dffba-a335-4d68-8642-e4da4bc23ce9",
             name: "Term A 2",
-            path: "Term A;Term A 2"
+            path: "Term A;Term A 2",
+            defaultLabel: "Term A 2"
           },
           isSelectable: true
         }
@@ -54,33 +62,39 @@ export const testData: ITreeViewItem<ITerm | null> = {
       value: {
         id: "ab763b5c-9d6f-4478-a798-072f5f7a6c8c",
         name: "Term A",
-        path: "Term A"
+        path: "Term A",
+        defaultLabel: "Term A"
       },
       isSelectable: false
     },
     {
       id: "b674db32-f58b-4b6a-b1d1-8f490a715467",
       label: "Term B",
+      defaultLabel: "Term B",
       children: [
         {
           id: "b7f6dc36-d980-4060-94cf-1cd15d5ba8ae",
           label: "Term B 1",
+          defaultLabel: "Term B 1",
           children: [],
           value: {
             id: "b7f6dc36-d980-4060-94cf-1cd15d5ba8ae",
             name: "Term B 1",
-            path: "Term B;Term B 1"
+            path: "Term B;Term B 1",
+            defaultLabel: "Term B 1"
           },
           isSelectable: true
         },
         {
           id: "22d13bf3-e495-4f04-bbb8-394779f6b498",
           label: "Term B 2",
+          defaultLabel: "Term B 2",
           children: [],
           value: {
             id: "22d13bf3-e495-4f04-bbb8-394779f6b498",
             name: "Term B 2",
-            path: "Term B;Term B 2"
+            path: "Term B;Term B 2",
+            defaultLabel: "Term B 2"
           },
           isSelectable: true
         }
@@ -88,7 +102,8 @@ export const testData: ITreeViewItem<ITerm | null> = {
       value: {
         id: "b674db32-f58b-4b6a-b1d1-8f490a715467",
         name: "Term B",
-        path: "Term B"
+        path: "Term B",
+        defaultLabel: "Term B"
       },
       isSelectable: true
     }

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -130,6 +130,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
               itemLimit={this.props.itemLimit}
               defaultLabelOnly={this.props.defaultLabelOnly}
               exactMatchOnly={this.props.exactMatchOnly}
+              lcid={this.props.lcid}
             />
           )}
         </div>
@@ -289,7 +290,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
     }
 
     const taxonomyApi = new TaxonomyApi(apiContext);
-    const newTerm = await taxonomyApi.createTerm(input, generatedTermId);
+    const newTerm = await taxonomyApi.createTerm(input, generatedTermId, this.props.lcid);
 
     return newTerm;
   }

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -7,6 +7,7 @@ import { ITerm } from "../../model/ITerm";
 export interface ITaxonomyPickerProps extends IBaseProps {
   absoluteSiteUrl: string;
   label?: string;
+  lcid?: number;
   required?: boolean;
   disabled?: boolean;
   isLoading?: boolean;

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
@@ -59,7 +59,7 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
       >
         <TreeLabel
           id={item.id}
-          label={item.label}
+          label={item.defaultLabel ? item.defaultLabel : item.label}
           hasChildren={item.children && item.children.length > 0}
           isRootNode={isRootNode}
           isSelected={selection.isKeySelected(item.id)}

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
@@ -13,6 +13,7 @@ export interface ITreeViewProps<T> {
 export interface ITreeViewItem<T> {
   id: string;
   label: string;
+  defaultLabel: string;
   value: T | null;
   children?: ITreeViewItem<T>[];
   isSelectable?: boolean;

--- a/packages/react-fabric-taxonomypicker/src/model/ITerm.ts
+++ b/packages/react-fabric-taxonomypicker/src/model/ITerm.ts
@@ -1,5 +1,6 @@
 export interface ITerm {
   id?: string;
+  defaultLabel: string;
   name: string;
   path: string;
   properties?: ITermProperties;


### PR DESCRIPTION
You can now pass an "lcid" property to the TaxonomyPicker component. If you omit this, it will be defaulted to 1033 (English). 
* The labels in the taxonomy picker dialog will be in the language based on the passed on lcid, otherwise in English
* When creating a new term in a given language, the default label of that language will be set (but also the default English label)

A couple of remarks:
* Translation is not maintained through this component. This means users would still need to go to the term store management to translate the created / existing terms
* Searching the taxonomy tree is done with all labels included, so also the translations even if the user's language differs from the executed search language