### PR TITLE
Bug fixing translated term selection

### DIFF
--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-14-09-00.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-14-09-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "Bug in selecting translated term: label was not translated in the selection input",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "klaas.lauwers@delaware.pro"
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermPicker.tsx
@@ -14,9 +14,11 @@ export interface ITermPickerProps extends IBasePickerProps<ITerm> { }
 export class TermPicker extends BasePicker<ITerm, ITermPickerProps> {
   protected static defaultProps: Partial<ITermPickerProps> = {
     onRenderItem: (props: IPickerItemProps<ITerm>) => {
-      return <TermItem {...props}>
+      return (
+        <TermItem {...props}>
           {props.item.defaultLabel ? props.item.defaultLabel : props.item.name}
-        </TermItem>;
+        </TermItem>
+      );
     },
     onRenderSuggestionsItem: (props: ITerm) => <TermSuggestion {...props} />,
     getTextFromItem: item => item.defaultLabel ? item.defaultLabel : item.name

--- a/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermPicker.tsx
@@ -14,9 +14,11 @@ export interface ITermPickerProps extends IBasePickerProps<ITerm> { }
 export class TermPicker extends BasePicker<ITerm, ITermPickerProps> {
   protected static defaultProps: Partial<ITermPickerProps> = {
     onRenderItem: (props: IPickerItemProps<ITerm>) => {
-      return <TermItem {...props}>{props.item.name}</TermItem>;
+      return <TermItem {...props}>
+          {props.item.defaultLabel ? props.item.defaultLabel : props.item.name}
+        </TermItem>;
     },
     onRenderSuggestionsItem: (props: ITerm) => <TermSuggestion {...props} />,
-    getTextFromItem: item => item.name
+    getTextFromItem: item => item.defaultLabel ? item.defaultLabel : item.name
   };
 }


### PR DESCRIPTION
Selecting a term in the taxonomy picker that has a translation for the current user's locale ID was not translated in the selected input box. 