### PR TITLE
Node selection mechanism

### DIFF
--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-17-13-56.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2018-12-17-13-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "First selected node in picker is also selected in dialog",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "klaaslauwers@gmail.com"
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -67,6 +67,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
         <div className={css(getClassName("TaxonomyDialog-Tree"), styles.taxonomyTree)}>
           <TreeView
             termSetId={this.props.termSetId}
+            selectedItems={this.state.selectedItems}
             isOpenTermSet={this.state.isOpenTermSet}
             data={this.state.treeViewData}
             onItemInvoked={this._onTreeItemInvoked}
@@ -124,6 +125,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
         defaultLabel: termTree.termSetName,
         children,
         value: null,
+        expanded: true,
         isSelectable: termTree.isOpenTermSet
       },
       itemAdding,
@@ -133,7 +135,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
 
   @autobind
   private _termToTreeViewItem(item: ITerm): ITreeViewItem<ITerm> {
-    return {
+    const treeViewItem: ITreeViewItem<ITerm> = {
       id: item.id!,
       label: item.name,
       defaultLabel: item.defaultLabel,
@@ -149,6 +151,34 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
           : [],
       isSelectable: item.properties && item.properties.isSelectable
     };
+
+    treeViewItem.expanded = this._isExpanded(treeViewItem);
+
+    return treeViewItem;
+  }
+
+  @autobind
+  private _isExpanded(item: ITreeViewItem<ITerm>): boolean {
+    if (this.props.defaultSelectedItems && this.props.defaultSelectedItems.length > 0) {
+      if (item.id === this.props.defaultSelectedItems[0].id) {
+        return true;
+      } else if (item.children) {
+        return this._isExpandedChild(item.children);
+      }
+    }
+
+    return false;
+  }
+
+  private _isExpandedChild(items: ITreeViewItem<ITerm>[]): boolean {
+    for (let i = 0; i < items.length; i++) {
+      const isExpanded: boolean = this._isExpanded(items[i]);
+      if (isExpanded) {
+        return isExpanded;
+      }
+    }
+
+    return false;
   }
 
   @autobind

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
@@ -31,7 +31,6 @@ export interface ITreeNodeState {
 export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeState> {
   constructor(props: ITreeNodeProps<T>) {
     super(props);
-
     this.state = {
       isCollapsed: !props.item.expanded
     };

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeNode.tsx
@@ -15,6 +15,7 @@ export interface ITreeNodeProps<T> {
   isOpenTermSet: boolean;
   isRootNode: boolean;
   defaultExpanded?: boolean;
+  firstSelectedItemId?: string;
   itemAdding?: boolean;
   newItemValue?: string;
   onNewItemValueChanged?: (value: string) => void;
@@ -32,7 +33,7 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
     super(props);
 
     this.state = {
-      isCollapsed: !props.defaultExpanded
+      isCollapsed: !props.item.expanded
     };
   }
   public render(): JSX.Element {
@@ -84,22 +85,24 @@ export class TreeNode<T> extends React.Component<ITreeNodeProps<T>, ITreeNodeSta
 
         {!isCollapsed &&
           item.children &&
-          item.children.map((child, index) => (
-            <TreeNode
-              key={child.id}
-              item={child}
-              isRootNode={false}
-              selection={selection}
-              isOpenTermSet={isOpenTermSet}
-              defaultExpanded={isRootNode && index === 0}
-              invokeItem={invokeItem}
-              onNewItemValueChanged={onNewItemValueChanged}
-              onNewItemFocusOut={onNewItemFocusOut}
-              onNewItemKeyPress={onNewItemKeyPress}
-              itemAdding={itemAdding}
-              newItemValue={newItemValue}
-            />
-          ))}
+          item.children.map((child, index) => {
+            return (
+              <TreeNode
+                key={child.id}
+                item={child}
+                isRootNode={false}
+                selection={selection}
+                isOpenTermSet={isOpenTermSet}
+                defaultExpanded={child.expanded}
+                invokeItem={invokeItem}
+                onNewItemValueChanged={onNewItemValueChanged}
+                onNewItemFocusOut={onNewItemFocusOut}
+                onNewItemKeyPress={onNewItemKeyPress}
+                itemAdding={itemAdding}
+                newItemValue={newItemValue}
+              />
+            );
+          })}
       </div>
     );
   }

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.tsx
@@ -21,12 +21,14 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
   constructor(props: ITreeViewProps<T>) {
     super(props);
 
+    const selection: Selection = new Selection({
+      onSelectionChanged: this._onSelectionChanged,
+      selectionMode: SelectionMode.single,
+      canSelectItem: (item: IObjectWithKey & ITreeViewItem<T>) => !!item.isSelectable
+    });
+
     this.state = {
-      selection: new Selection({
-        onSelectionChanged: this._onSelectionChanged,
-        selectionMode: SelectionMode.single,
-        canSelectItem: (item: IObjectWithKey & ITreeViewItem<T>) => !!item.isSelectable
-      })
+      selection
     };
 
     this._setSelectableItems(props.data);
@@ -34,6 +36,9 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
 
   public componentDidMount() {
     this._hasMounted = true;
+
+    // Update selected nodes
+
   }
 
   public componentWillReceiveProps(newProps: ITreeViewProps<T>) {
@@ -43,14 +48,19 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
   }
 
   public render(): JSX.Element {
-    const { data, isOpenTermSet, onItemInvoked, onNewItemValueChanged, onNewItemFocusOut, onNewItemKeyPress, itemAdding } = this.props;
+    const { data, isOpenTermSet, selectedItems, onItemInvoked, onNewItemValueChanged, onNewItemFocusOut, onNewItemKeyPress, itemAdding } = this.props;
     const { selection } = this.state;
+
+    const firstSelectedItemId: string = selectedItems ? selectedItems.filter(x => !!x.id).map(x => {
+      return x.id!;
+    })[0] : "";
 
     return (
       <div>
         {data && (
           <TreeNode
             item={data}
+            firstSelectedItemId={firstSelectedItemId}
             selection={selection}
             defaultExpanded={true}
             isRootNode={true}
@@ -94,5 +104,10 @@ export class TreeView<T> extends React.Component<ITreeViewProps<T>, ITreeViewSta
       : [];
 
     this.state.selection.setItems(flattenedData, false);
+
+    if (this.props.selectedItems && this.props.selectedItems.length > 0) {
+      // Only select first item
+      this.state.selection.setKeySelected(this.props.selectedItems[0].id!, true, false);
+    }
   }
 }

--- a/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TreeView/TreeView.types.ts
@@ -1,8 +1,11 @@
+import { ITerm } from "src/model/ITerm";
+
 export interface ITreeViewProps<T> {
   data?: ITreeViewItem<T>;
   termSetId: string;
   itemAdding: boolean;
   isOpenTermSet: boolean;
+  selectedItems?: ITerm[];
   onSelectionChanged?: (value: T | null) => void;
   onItemInvoked?: (item: ITreeViewItem<T>) => void;
   onNewItemFocusOut?: () => void;
@@ -14,6 +17,7 @@ export interface ITreeViewItem<T> {
   id: string;
   label: string;
   defaultLabel: string;
+  expanded?: boolean;
   value: T | null;
   children?: ITreeViewItem<T>[];
   isSelectable?: boolean;


### PR DESCRIPTION
Stuff to mimic the behavior of the OOTB taxonomy picker:
- The first selected node in the term picker is now also selected in the taxonomy dialog
- The full path towards this node is expanded in the dialog

