### PR TITLE
ShowTranslatedLabels property for performance reasons. Fixing some small bugs

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
@@ -15,7 +15,7 @@
       "description": { "default": " " },
       "officeFabricIconFontName": "Page",
       "properties": {
-        "searchTranslatedLabels": true,
+        "showTranslatedLabels": true,
         "itemLimit": 5,
         "lcid": 1033
       }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.manifest.json
@@ -15,6 +15,7 @@
       "description": { "default": " " },
       "officeFabricIconFontName": "Page",
       "properties": {
+        "searchTranslatedLabels": true,
         "itemLimit": 5,
         "lcid": 1033
       }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
@@ -17,7 +17,7 @@ export interface ITaxonomyPickerDemoWebPartProps {
   rootTermId: string;
   itemLimit: number;
   lcid: number;
-  searchTranslatedLabels: boolean;
+  showTranslatedLabels: boolean;
 }
 
 export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
@@ -32,7 +32,7 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
         rootTermId: this.properties.rootTermId,
         itemLimit: this.properties.itemLimit,
         lcid: this.properties.lcid,
-        searchTranslatedLabels: this.properties.searchTranslatedLabels
+        showTranslatedLabels: this.properties.showTranslatedLabels
       }
     );
 
@@ -66,9 +66,9 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
                 PropertyPaneTextField("lcid", {
                   label: strings.LcidFieldLabel
                 }),
-                PropertyPaneToggle("searchTranslatedLabels", {
-                  label: strings.SearchTranslatedLabelsLabel,
-                  checked: this.properties.searchTranslatedLabels
+                PropertyPaneToggle("showTranslatedLabels", {
+                  label: strings.ShowTranslatedLabelsLabel,
+                  checked: this.properties.showTranslatedLabels
                 })
               ]
             }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/TaxonomyPickerDemoWebPart.ts
@@ -2,7 +2,8 @@ import { Version } from "@microsoft/sp-core-library";
 import {
   BaseClientSideWebPart,
   IPropertyPaneConfiguration,
-  PropertyPaneTextField
+  PropertyPaneTextField,
+  PropertyPaneToggle
 } from "@microsoft/sp-webpart-base";
 import * as React from "react";
 import * as ReactDom from "react-dom";
@@ -16,6 +17,7 @@ export interface ITaxonomyPickerDemoWebPartProps {
   rootTermId: string;
   itemLimit: number;
   lcid: number;
+  searchTranslatedLabels: boolean;
 }
 
 export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
@@ -29,7 +31,8 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
         termSetId: this.properties.termSetId,
         rootTermId: this.properties.rootTermId,
         itemLimit: this.properties.itemLimit,
-        lcid: this.properties.lcid
+        lcid: this.properties.lcid,
+        searchTranslatedLabels: this.properties.searchTranslatedLabels
       }
     );
 
@@ -62,6 +65,10 @@ export default class TaxonomyPickerDemoWebPart extends BaseClientSideWebPart<
                 }),
                 PropertyPaneTextField("lcid", {
                   label: strings.LcidFieldLabel
+                }),
+                PropertyPaneToggle("searchTranslatedLabels", {
+                  label: strings.SearchTranslatedLabelsLabel,
+                  checked: this.properties.searchTranslatedLabels
                 })
               ]
             }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
@@ -4,4 +4,5 @@ export interface ITaxonomyPickerDemoProps {
   rootTermId: string;
   itemLimit: number;
   lcid: number;
+  searchTranslatedLabels: boolean;
 }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoProps.ts
@@ -4,5 +4,5 @@ export interface ITaxonomyPickerDemoProps {
   rootTermId: string;
   itemLimit: number;
   lcid: number;
-  searchTranslatedLabels: boolean;
+  showTranslatedLabels: boolean;
 }

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -16,6 +16,7 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
           itemLimit={this.props.itemLimit}
           allowAddTerms={true}
           lcid={this.props.lcid}
+          searchTranslatedLabels={this.props.searchTranslatedLabels}
         />
       </div>
     );

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -16,7 +16,7 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
           itemLimit={this.props.itemLimit}
           allowAddTerms={true}
           lcid={this.props.lcid}
-          searchTranslatedLabels={this.props.searchTranslatedLabels}
+          showTranslatedLabels={this.props.showTranslatedLabels}
         />
       </div>
     );

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerLoader.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerLoader.tsx
@@ -7,8 +7,6 @@ import { SPComponentLoader } from "@microsoft/sp-loader";
 import * as React from "react";
 
 export interface ITaxonomyPickerLoaderProps extends ITaxonomyPickerProps {
-  absoluteSiteUrl: string;
-  lcid: number;
 }
 
 export interface ITaxonomyPickerLoaderState {

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
@@ -5,6 +5,7 @@ define([], function () {
     TermSetIdFieldLabel: "Term Set ID",
     RootTermIdFieldLabel: "Root Term ID",
     ItemLimitFieldLabel: "Item Limit",
-    LcidFieldLabel: "Locale ID"
+    LcidFieldLabel: "Locale ID",
+    SearchTranslatedLabelsLabel: "Search Translated Labels"
   };
 });

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/en-us.js
@@ -6,6 +6,6 @@ define([], function () {
     RootTermIdFieldLabel: "Root Term ID",
     ItemLimitFieldLabel: "Item Limit",
     LcidFieldLabel: "Locale ID",
-    SearchTranslatedLabelsLabel: "Search Translated Labels"
+    ShowTranslatedLabelsLabel: "Search Translated Labels"
   };
 });

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
@@ -5,7 +5,7 @@ declare interface ITaxonomyPickerDemoWebPartStrings {
   RootTermIdFieldLabel: string;
   ItemLimitFieldLabel: string;
   LcidFieldLabel: string;
-  SearchTranslatedLabelsLabel: string;
+  ShowTranslatedLabelsLabel: string;
 }
 
 declare module "TaxonomyPickerDemoWebPartStrings" {

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/loc/mystrings.d.ts
@@ -5,6 +5,7 @@ declare interface ITaxonomyPickerDemoWebPartStrings {
   RootTermIdFieldLabel: string;
   ItemLimitFieldLabel: string;
   LcidFieldLabel: string;
+  SearchTranslatedLabelsLabel: string;
 }
 
 declare module "TaxonomyPickerDemoWebPartStrings" {

--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2019-01-08-14-33.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/master_2019-01-08-14-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "x) Added showTranslatedLabels property to show or hide the translated labels in the term pickers for performance reasons. Setting to false will get rid of the long getDefaultLabel queries per term. x) Updated demo: lcid was not properly passed along. x) Bug when searching for strange characters in taxonomy dialog term picker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "klaaslauwers@gmail.com"
+}

--- a/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.ts
+++ b/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.ts
@@ -20,7 +20,7 @@ export class TaxonomyApi {
     this.cacheKey = this._getCacheKey();
   }
 
-  public async getTerms(lcid: number = 1033, noCache: boolean = false, searchTranslatedLabels: boolean = false): Promise<ITerm[]> {
+  public async getTerms(lcid: number = 1033, noCache: boolean = false, showTranslatedLabels: boolean = false): Promise<ITerm[]> {
     if (!noCache) {
       const cachedData = TaxonomyApi.CACHEDATA[this.cacheKey];
 
@@ -29,7 +29,7 @@ export class TaxonomyApi {
       }
     }
 
-    const termData = await this._getTermsInteral(lcid, searchTranslatedLabels);
+    const termData = await this._getTermsInteral(lcid, showTranslatedLabels);
 
     // write data to cache
     if (!noCache) {
@@ -40,7 +40,7 @@ export class TaxonomyApi {
   }
 
   public async findTerms(filter: string, lcid: number = 1033, defaultLabelOnly?: boolean,
-    exactMatch?: boolean, searchTranslatedLabels?: boolean, resultSize?: number, trimUnavailable?: boolean): Promise<ITerm[]> {
+    exactMatch?: boolean, showTranslatedLabels?: boolean, resultSize?: number, trimUnavailable?: boolean): Promise<ITerm[]> {
     if (!filter || filter.length === 0) {
       return [];
     }
@@ -49,7 +49,7 @@ export class TaxonomyApi {
       resultSize = 10;
     }
 
-    const allTerms = await this.getTerms(lcid, false, searchTranslatedLabels);
+    const allTerms = await this.getTerms(lcid, false, showTranslatedLabels);
     let matchingTerms: ITerm[] = allTerms.filter(term => {
       let isMatch = true;
       if (exactMatch) {
@@ -163,7 +163,7 @@ export class TaxonomyApi {
     );
   }
 
-  private async _getTermsInteral(lcid: number = 1033, searchTranslatedLabels: boolean = false): Promise<ITerm[]> {
+  private async _getTermsInteral(lcid: number = 1033, showTranslatedLabels: boolean = false): Promise<ITerm[]> {
     const taxonomySession = SP.Taxonomy.TaxonomySession.getTaxonomySession(this.spContext);
     const termStore = taxonomySession.getDefaultSiteCollectionTermStore();
     const termSet = termStore.getTermSet(new SP.Guid(this.context.termSetId));
@@ -206,7 +206,7 @@ export class TaxonomyApi {
       const termLabels = currentTerm.get_labels();
       let termLabel: string = currentTerm.get_name();
 
-      if (searchTranslatedLabels) {
+      if (showTranslatedLabels) {
         const termLabelByLcid = currentTerm.getDefaultLabel(lcid);
         const termLabelEn = currentTerm.getDefaultLabel(1033);
 

--- a/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.ts
+++ b/packages/react-fabric-taxonomypicker/src/api/TaxonomyApi/TaxonomyApi.ts
@@ -44,6 +44,7 @@ export class TaxonomyApi {
     if (!filter || filter.length === 0) {
       return [];
     }
+
     if (!resultSize) {
       resultSize = 10;
     }

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -202,7 +202,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
       this.props.lcid,
       this.props.defaultLabelOnly,
       this.props.exactMatchOnly,
-      this.props.searchTranslatedLabels,
+      this.props.showTranslatedLabels,
       10,
       true
     );

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -4,7 +4,7 @@ import { css } from "@uifabric/utilities/lib/css";
 import { DefaultButton, PrimaryButton } from "office-ui-fabric-react/lib/Button";
 import { Dialog, DialogFooter, DialogType, IDialog } from "office-ui-fabric-react/lib/Dialog";
 import * as React from "react";
-
+import { replaceIllegalCharacters } from "../../utilities/invalidchars";
 import * as Guid from "uuid/v4";
 import { ITaxonomyApiContext, TaxonomyApi } from "../../api/TaxonomyApi";
 import { ITerm } from "../../model/ITerm";
@@ -198,9 +198,11 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
 
     const taxonomyApi = new TaxonomyApi(apiContext);
     const matchingTerms = await taxonomyApi.findTerms(
-      filter,
+      replaceIllegalCharacters(filter),
+      this.props.lcid,
       this.props.defaultLabelOnly,
       this.props.exactMatchOnly,
+      this.props.searchTranslatedLabels,
       10,
       true
     );

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
@@ -11,7 +11,7 @@ export interface ITaxonomyDialogProps extends IBaseProps {
   defaultSelectedItems?: ITerm[];
   pickerSuggestionsProps?: IBasePickerSuggestionsProps;
   itemLimit?: number;
-  searchTranslatedLabels?: boolean;
+  showTranslatedLabels?: boolean;
   defaultLabelOnly?: boolean;
   exactMatchOnly?: boolean;
 

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
@@ -11,6 +11,7 @@ export interface ITaxonomyDialogProps extends IBaseProps {
   defaultSelectedItems?: ITerm[];
   pickerSuggestionsProps?: IBasePickerSuggestionsProps;
   itemLimit?: number;
+  searchTranslatedLabels?: boolean;
   defaultLabelOnly?: boolean;
   exactMatchOnly?: boolean;
 

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -131,7 +131,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
               defaultLabelOnly={this.props.defaultLabelOnly}
               exactMatchOnly={this.props.exactMatchOnly}
               lcid={this.props.lcid}
-              searchTranslatedLabels={this.props.searchTranslatedLabels}
+              showTranslatedLabels={this.props.showTranslatedLabels}
             />
           )}
         </div>
@@ -153,7 +153,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
       this.props.lcid,
       this.props.defaultLabelOnly,
       this.props.exactMatchOnly,
-      this.props.searchTranslatedLabels,
+      this.props.showTranslatedLabels,
       10,
       true
     );

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -7,7 +7,7 @@ import { Label } from "office-ui-fabric-react/lib/Label";
 import { IBasePicker, ValidationState } from "office-ui-fabric-react/lib/Pickers";
 import * as React from "react";
 import * as Guid from "uuid/v4";
-
+import { replaceIllegalCharacters } from "../../utilities/invalidchars";
 import { ITaxonomyApiContext, TaxonomyApi } from "../../api/TaxonomyApi";
 import { ITerm } from "../../model/ITerm";
 import { getClassName } from "../../utilities";
@@ -131,6 +131,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
               defaultLabelOnly={this.props.defaultLabelOnly}
               exactMatchOnly={this.props.exactMatchOnly}
               lcid={this.props.lcid}
+              searchTranslatedLabels={this.props.searchTranslatedLabels}
             />
           )}
         </div>
@@ -148,9 +149,11 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
 
     const taxonomyApi = new TaxonomyApi(apiContext);
     const matchingTerms = await taxonomyApi.findTerms(
-      this._replaceIllegalCharacters(filter),
+      replaceIllegalCharacters(filter),
+      this.props.lcid,
       this.props.defaultLabelOnly,
       this.props.exactMatchOnly,
+      this.props.searchTranslatedLabels,
       10,
       true
     );
@@ -158,20 +161,6 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
     return matchingTerms.filter(
       item => !(selectedItems || []).some(selectedItem => selectedItem.id === item.id)
     );
-  }
-
-  private _replaceIllegalCharacters(termLabel: string): string {
-    let termLabelNew: string = this._replaceAll(termLabel, "\t", " ");
-    termLabelNew = this._replaceAll(termLabelNew, ";", ",");
-    termLabelNew = this._replaceAll(termLabelNew, "\"", "\uFF02");
-    termLabelNew = this._replaceAll(termLabelNew, "<", "\uFF1C");
-    termLabelNew = this._replaceAll(termLabelNew, ">", "\uFF1E");
-    termLabelNew = this._replaceAll(termLabelNew, "&", "＆");
-    return termLabelNew;
-  }
-
-  private _replaceAll(str: string, find: string, replace: string) {
-    return str.replace(new RegExp(find, "g"), replace);
   }
 
   @autobind

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -6,7 +6,7 @@ import { ITerm } from "../../model/ITerm";
 
 export interface ITaxonomyPickerProps extends IBaseProps {
   absoluteSiteUrl: string;
-  searchTranslatedLabels?: boolean;
+  showTranslatedLabels?: boolean;
   label?: string;
   lcid?: number;
   required?: boolean;

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -6,6 +6,7 @@ import { ITerm } from "../../model/ITerm";
 
 export interface ITaxonomyPickerProps extends IBaseProps {
   absoluteSiteUrl: string;
+  searchTranslatedLabels?: boolean;
   label?: string;
   lcid?: number;
   required?: boolean;

--- a/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermSuggestion.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TermPicker/TermSuggestion.tsx
@@ -6,15 +6,16 @@ import { getClassName } from "../../utilities";
 
 const styles = require("./TermPicker.module.scss");
 
-export interface ITermSuggestionProps extends ITerm {}
+export interface ITermSuggestionProps extends ITerm { }
 
 export const TermSuggestion: React.StatelessComponent<ITermSuggestionProps> = ({
   id,
   name,
+  defaultLabel,
   path
 }: ITerm) => (
-  <div className={css(getClassName("TermSuggestion"), styles.termSuggestion)}>
-    <div>{name}</div>
-    <div className={css(getClassName("TermSuggestion-TermPath"), styles.termPath)}>{path}</div>
-  </div>
-);
+    <div className={css(getClassName("TermSuggestion"), styles.termSuggestion)}>
+      <div>{defaultLabel ? defaultLabel : name}</div>
+      <div className={css(getClassName("TermSuggestion-TermPath"), styles.termPath)}>{path}</div>
+    </div>
+  );

--- a/packages/react-fabric-taxonomypicker/src/utilities/index.ts
+++ b/packages/react-fabric-taxonomypicker/src/utilities/index.ts
@@ -1,2 +1,3 @@
+export * from "./invalidchars";
 export * from "./flatten";
 export * from "./styling";

--- a/packages/react-fabric-taxonomypicker/src/utilities/invalidchars.ts
+++ b/packages/react-fabric-taxonomypicker/src/utilities/invalidchars.ts
@@ -1,0 +1,14 @@
+
+export function replaceIllegalCharacters(input: string): string {
+    let inputNew: string = replaceAll(input, "\t", " ");
+    inputNew = replaceAll(inputNew, ";", ",");
+    inputNew = replaceAll(inputNew, "\"", "\uFF02");
+    inputNew = replaceAll(inputNew, "<", "\uFF1C");
+    inputNew = replaceAll(inputNew, ">", "\uFF1E");
+    inputNew = replaceAll(inputNew, "&", "＆");
+    return inputNew;
+}
+
+export function replaceAll(str: string, find: string, replace: string) {
+    return str.replace(new RegExp(find, "g"), replace);
+}


### PR DESCRIPTION
1. Added showTranslatedLabels property to show or hide the translated labels in the term pickers for performance reasons. Setting to false will get rid of the long getDefaultLabel queries per term
2. Updated demo: lcid was not properly passed along
3. Bug when searching for strange characters in taxonomy dialog term picker