### PR TITLE
Allow custom title in taxonomy dialog term picker

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -9,6 +9,7 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
     return (
       <div className={styles.taxonomyPickerDemo}>
         <TaxonomyPickerLoader
+          title="Select your demo data"
           absoluteSiteUrl={this.props.absoluteSiteUrl}
           label="Demo picker"
           termSetId={this.props.termSetId}

--- a/packages/react-fabric-taxonomypicker/CHANGELOG.json
+++ b/packages/react-fabric-taxonomypicker/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
   "entries": [
     {
+      "version": "1.10.0",
+      "tag": "@dlw-digitalworkplace/react-fabric-taxonomypicker_v1.10.0",
+      "date": "Mon, 28 Jan 2019 17:41:10 GMT",
+      "comments": {
+        "minor": [
+          {
+            "comment": "x) Allow custom title in taxonomy dialog term picker"
+          }
+        ]
+      }
+    },
+    {
       "version": "1.9.0",
       "tag": "@dlw-digitalworkplace/react-fabric-taxonomypicker_v1.9.0",
       "date": "Tue, 08 Jan 2019 14:48:10 GMT",

--- a/packages/react-fabric-taxonomypicker/package.json
+++ b/packages/react-fabric-taxonomypicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -59,11 +59,12 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
           className: styles.dialog
         }}
         onDismiss={this._onDismiss}
-        dialogContentProps={{ type: DialogType.close, title: "Browse Term Set" }}
+        dialogContentProps={{
+          type: DialogType.close,
+          title: this.props.title || "Browse Term Set"
+        }}
       >
-        {this.state.isOpenTermSet &&
-          <TermAdder addNewItemClick={this._onAddNewItemClick} />
-        }
+        {this.state.isOpenTermSet && <TermAdder addNewItemClick={this._onAddNewItemClick} />}
         <div className={css(getClassName("TaxonomyDialog-Tree"), styles.taxonomyTree)}>
           <TreeView
             termSetId={this.props.termSetId}

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
@@ -5,6 +5,7 @@ import { ITerm } from "../../model/ITerm";
 import { ITreeViewItem } from "../TreeView";
 
 export interface ITaxonomyDialogProps extends IBaseProps {
+  title?: string;
   absoluteSiteUrl: string;
   termSetId: string;
   rootTermId?: string;

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -120,6 +120,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
 
           {this.state.isPopupOpen && (
             <TaxonomyDialog
+              title={this.props.title}
               absoluteSiteUrl={this.props.absoluteSiteUrl}
               defaultSelectedItems={this.state.items}
               termSetId={this.props.termSetId}
@@ -185,7 +186,9 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
   }
 
   private _getRequestedTerm(input: string) {
-    const requestedTerms = this.requestedTerms.filter((rt) => { return rt.label === input; });
+    const requestedTerms = this.requestedTerms.filter(rt => {
+      return rt.label === input;
+    });
     const requestedTerm = requestedTerms.length > 0 ? requestedTerms[0] : null;
     return requestedTerm;
   }

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -6,6 +6,7 @@ import { ITerm } from "../../model/ITerm";
 
 export interface ITaxonomyPickerProps extends IBaseProps {
   absoluteSiteUrl: string;
+  title?: string;
   showTranslatedLabels?: boolean;
   label?: string;
   lcid?: number;


### PR DESCRIPTION
The change allows you to set your own title when the dialog picker has been opened.
As a fallback the default text: "Browse Term Set" is set if no title has been given. 

