### PR TITLE
Bugfix for leading and trailing spaces in term suggestions

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoState.ts
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/ITaxonomyPickerDemoState.ts
@@ -1,0 +1,5 @@
+import { ITerm } from "@dlw-digitalworkplace/react-fabric-taxonomypicker/lib/model/ITerm";
+
+export interface ITaxonomyPickerDemoState {
+  selectedTerms: ITerm[];
+}

--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -1,10 +1,20 @@
+import { ITerm } from "@dlw-digitalworkplace/react-fabric-taxonomypicker/lib/model/ITerm";
 import * as React from "react";
 
 import { ITaxonomyPickerDemoProps } from "./ITaxonomyPickerDemoProps";
+import { ITaxonomyPickerDemoState } from "./ITaxonomyPickerDemoState";
 import styles from "./TaxonomyPickerDemo.module.scss";
 import { TaxonomyPickerLoader } from "./TaxonomyPickerLoader";
 
-export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerDemoProps, {}> {
+export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerDemoProps, ITaxonomyPickerDemoState> {
+
+  constructor(props: ITaxonomyPickerDemoProps) {
+    super(props);
+    this.state = {
+      selectedTerms: []
+    };
+  }
+
   public render(): React.ReactElement<ITaxonomyPickerDemoProps> {
     return (
       <div className={styles.taxonomyPickerDemo}>
@@ -18,8 +28,18 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
           allowAddTerms={true}
           lcid={this.props.lcid}
           showTranslatedLabels={this.props.showTranslatedLabels}
+          selectedItems={this.state.selectedTerms}
+          onChange={this._onChange}
         />
       </div>
     );
+  }
+
+  private _onChange = (newValue?: ITerm[]): void => {
+    this.setState({
+      selectedTerms: newValue
+    }, () => {
+      console.dir(this.state.selectedTerms);
+    });
   }
 }

--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/bugfix-termSpaces_2019-07-03-13-11.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/bugfix-termSpaces_2019-07-03-13-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "Bugfix for leading and trailing spaces in resolve terms",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "robin.agten@delaware.pro"
+}

--- a/packages/react-fabric-taxonomypicker/src/utilities/invalidchars.ts
+++ b/packages/react-fabric-taxonomypicker/src/utilities/invalidchars.ts
@@ -1,14 +1,19 @@
 
 export function replaceIllegalCharacters(input: string): string {
-    let inputNew: string = replaceAll(input, "\t", " ");
-    inputNew = replaceAll(inputNew, ";", ",");
-    inputNew = replaceAll(inputNew, "\"", "\uFF02");
-    inputNew = replaceAll(inputNew, "<", "\uFF1C");
-    inputNew = replaceAll(inputNew, ">", "\uFF1E");
-    inputNew = replaceAll(inputNew, "&", "＆");
-    return inputNew;
+  let inputNew: string = replaceAll(input, "\t", " ");
+  inputNew = replaceAll(inputNew, ";", ",");
+  inputNew = replaceAll(inputNew, "\"", "\uFF02");
+  inputNew = replaceAll(inputNew, "<", "\uFF1C");
+  inputNew = replaceAll(inputNew, ">", "\uFF1E");
+  inputNew = replaceAll(inputNew, "&", "＆");
+  inputNew = trimSpaces(inputNew);
+  return inputNew;
 }
 
 export function replaceAll(str: string, find: string, replace: string) {
-    return str.replace(new RegExp(find, "g"), replace);
+  return str.replace(new RegExp(find, "g"), replace);
+}
+
+export function trimSpaces(str: string) {
+  return str.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
#### Type

* [ ] Feature
* [X] Bug

#### Package

* [ ] dvine-components-tslint
* [ ] react-fabric-peoplepicker
* [x] react-fabric-taxonomypicker

#### General Information
> This pull request contains a bugfix for selecting terms with trailing or leading spaces. 

#### Issue description
When searching for a term, the suggestions don't take trailing or leading spaces into account. 
e.g. The term set contains a term "My Term", and the search term in the dropdown is "My Term " (with extra space at the end). The term will not be found so it is possible to add it as a new term (given this option is enabled in the taxonomy picker). Because the termset does not allow terms with trailing or leading spaces, there is no new term created, but the taxonomy picker thinks there is and returns a new term with a new id and trailing space. The same happens with leading spaces or multiple spaces between words. 

#### Solution
When the suggestions are resolved, remove the leading, trailing and excessive spaces. Searching for "   My   Term   " will actually search for "My Term". Because of this, the taxonomy picker can't be fooled into creating terms with leading, trailing or excessive spaces