### PR TITLE
Bugfix for creating terms with only spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ import { TaxonomyPicker } from "@dlw-digitalworkplace/react-fabric-taxonomypicke
 ```
 
 # Contributing
-
-This project uses [Rush](https://rushjs.io/) as a monorepo manager, which includes automatic changelog creation.
-Therefore, before submitting the pull request, **run `rush version` on your code and commit the generated change file**.
+ 1. Fork the repository to your local GitHub
+ 2. Clone the code
+ 3. Create a new branch for your hotfix or feature
+ 4. Run `npm install` in the root of the project to install all the dependencies
+ 5. Run `npm run build` to build the code
+ 6. Run `npm run start:nb` to run the sample app and test the components in the workbench
+ 7. Make the code changes
+ 8. Stage and commit your changes in the local branch
+ 9. Run `rush change` to generate the cange file
+ 10. Stage and commit the generated change file 
+ 11. Push all the changes to the remote branch
+ 12. Merge the branch created in step 3 to the master branch of your git repo
+ 13. Make sure the master branch builds (`npm run build`)
+ 14. Create a pull request to get your changes in the @dlw-digitalworkplace package
+ 
+ 
+   
+ 

--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/bugfix-allSpacesCanBeAdded_2019-07-04-09-10.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/bugfix-allSpacesCanBeAdded_2019-07-04-09-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "Fix for adding empty terms to the term set",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "robin.agten@delaware.pro"
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -7,10 +7,11 @@ import { Label } from "office-ui-fabric-react/lib/Label";
 import { IBasePicker, ValidationState } from "office-ui-fabric-react/lib/Pickers";
 import * as React from "react";
 import * as Guid from "uuid/v4";
-import { replaceIllegalCharacters } from "../../utilities/invalidchars";
+
 import { ITaxonomyApiContext, TaxonomyApi } from "../../api/TaxonomyApi";
 import { ITerm } from "../../model/ITerm";
 import { getClassName } from "../../utilities";
+import { replaceIllegalCharacters } from "../../utilities/invalidchars";
 import { TaxonomyDialog } from "../TaxonomyDialog";
 import { TermPicker } from "../TermPicker";
 import { ITaxonomyPickerProps } from "./TaxonomyPicker.types";
@@ -239,7 +240,8 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
       !this.props.allowAddTerms ||
       !this.state.isLoaded ||
       !input ||
-      this.state.items.some(item => item.name.toLowerCase() === input.toLowerCase())
+      this.state.items.some(item => item.name.toLowerCase() === input.toLowerCase()) ||
+      input.replace(/\s/g, "").length === 0
     ) {
       return ValidationState.invalid;
     }


### PR DESCRIPTION
#### Type
  * [ ] Feature
  * [x] Bug

#### Package
  * [ ] dvine-components-tslint
  * [ ] react-fabric-peoplepicker
  * [x] react-fabric-taxonomypicker

#### General Information
>This pull request contains a bugfix for adding terms to the term set that only contains spaces.

#### Issue description
When searching for a term in the taxonomy picker, it is possible to add a term that contains only spaces. The taxonomy picker thinks the term is created and returns a new Guid and the label of the term. The term isn't actually created because it is not possible to add terms with only spaces.

#### Solution
Added extra validation in the 'add term' functionality so that a term with only spaces cannot be added

#### Note: 
> I also updated the contribution guidelines so make it more descriptive. 