### PR TITLE
Small Taxonomypicker bugfixes

### DIFF
--- a/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
+++ b/apps/spfx-demo-app/src/webparts/taxonomyPickerDemo/components/TaxonomyPickerDemo.tsx
@@ -25,7 +25,7 @@ export default class TaxonomyPickerDemo extends React.Component<ITaxonomyPickerD
           termSetId={this.props.termSetId}
           rootTermId={this.props.rootTermId}
           itemLimit={this.props.itemLimit}
-          allowAddTerms={true}
+          allowAddTerms={false}
           lcid={this.props.lcid}
           showTranslatedLabels={this.props.showTranslatedLabels}
           selectedItems={this.state.selectedTerms}

--- a/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/hotfix-AddTermInDialog_2019-07-12-11-19.json
+++ b/common/changes/@dlw-digitalworkplace/react-fabric-taxonomypicker/hotfix-AddTermInDialog_2019-07-12-11-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+      "comment": "1. Bugfix for adding terms in the picker dialog when not allowed 2. Bugfix for selecting root term in the picker dialog treeview",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@dlw-digitalworkplace/react-fabric-taxonomypicker",
+  "email": "robin.agten@delaware.pro"
+}

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.tsx
@@ -4,15 +4,16 @@ import { css } from "@uifabric/utilities/lib/css";
 import { DefaultButton, PrimaryButton } from "office-ui-fabric-react/lib/Button";
 import { Dialog, DialogFooter, DialogType, IDialog } from "office-ui-fabric-react/lib/Dialog";
 import * as React from "react";
-import { replaceIllegalCharacters } from "../../utilities/invalidchars";
 import * as Guid from "uuid/v4";
+
 import { ITaxonomyApiContext, TaxonomyApi } from "../../api/TaxonomyApi";
 import { ITerm } from "../../model/ITerm";
 import { getClassName } from "../../utilities";
+import { replaceIllegalCharacters } from "../../utilities/invalidchars";
+import { TermAdder } from "../TermAdder";
 import { TermPicker } from "../TermPicker";
 import { ITreeViewItem, TreeView } from "../TreeView";
 import { ITaxonomyDialogProps } from "./TaxonomyDialog.types";
-import { TermAdder } from "../TermAdder";
 
 const styles = require("./TaxonomyDialog.module.scss");
 
@@ -64,7 +65,7 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
           title: this.props.title || "Browse Term Set"
         }}
       >
-        {this.state.isOpenTermSet && <TermAdder addNewItemClick={this._onAddNewItemClick} />}
+        {this.state.isOpenTermSet && this.props.allowAddTerms && <TermAdder addNewItemClick={this._onAddNewItemClick} />}
         <div className={css(getClassName("TaxonomyDialog-Tree"), styles.taxonomyTree)}>
           <TreeView
             termSetId={this.props.termSetId}
@@ -247,6 +248,8 @@ export class TaxonomyDialog extends BaseComponent<ITaxonomyDialogProps, ITaxonom
 
   @autobind
   private _onTreeItemInvoked(item: ITreeViewItem<ITerm>): void {
+    if (!item.value) { return; }
+
     this._addItem(item.value!);
   }
 

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyDialog/TaxonomyDialog.types.ts
@@ -15,6 +15,7 @@ export interface ITaxonomyDialogProps extends IBaseProps {
   showTranslatedLabels?: boolean;
   defaultLabelOnly?: boolean;
   exactMatchOnly?: boolean;
+  allowAddTerms?: boolean;
 
   isOpen?: boolean;
 

--- a/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
+++ b/packages/react-fabric-taxonomypicker/src/components/TaxonomyPicker/TaxonomyPicker.tsx
@@ -136,6 +136,7 @@ export class TaxonomyPicker extends BaseComponent<ITaxonomyPickerProps, ITaxonom
               exactMatchOnly={this.props.exactMatchOnly}
               lcid={this.props.lcid}
               showTranslatedLabels={this.props.showTranslatedLabels}
+              allowAddTerms={this.props.allowAddTerms}
             />
           )}
         </div>


### PR DESCRIPTION
#### Type
 - [ ] Feature
 - [x] Bug

#### Package
 - [ ] dvine-components-tslint
 - [ ] react-fabric-peoplepicker
 - [X] react-fabric-taxonomypicker

#### General Information
This pull request contains 2 small bugfixes

1. It was possible to add terms to the term set using the picker dialog even when the 'allowAddTerms' property was set to false
2. When double-clicking on the term set name in the picker dialog, the a javascript error was thrown.

#### Solution
1. Added extra validation in the taxonomy picker dialog to not show the 'Add Term' message when the 'allowAddTerms' property is set to false
2. Added extra validation so that when the term set name is clicked in the taxonomy picker tree view, the 'AddTerm' functionality is not executed